### PR TITLE
Fix changelog dates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,13 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.4.7] - 2025-03-12
+## [1.4.7] - 2026-03-12
 
 ### Fixed
 
 - Encore une MEP non reconnue dans l'EP5
 
-## [1.4.6] - 2025-03-11
+## [1.4.6] - 2026-03-11
 
 ### Changed
 


### PR DESCRIPTION
`CHANGELOG.md` presented year errors for versions `1.4.6` and `1.4.7`.

These have been fixed to reflect the correct commit dates.