### PR TITLE
Allow for whitespace before colon

### DIFF
--- a/src/parsers/nightsAFParser.js
+++ b/src/parsers/nightsAFParser.js
@@ -18,7 +18,7 @@ export const nightsAFParser = (text, fileName, fileOrder, taxYear) => {
     let result = {"type": "nights", fileName, fileOrder, errors: []};
     let total;
     try {
-        total = matchFirst(text, /compte s'élève à:\s([\-0-9,. ]+)\sEuros/);
+        total = matchFirst(text, /compte s'élève à\s?:\s([\-0-9,. ]+)\sEuros/);
         total = parseFloat(total.replace(/\s+/g, '').replace(',', '.'));
     }catch(err) {
         result.errors.push({"type": "error", "message":"Montant des nuitées AF non trouvé"})


### PR DESCRIPTION
This PR updates the regular expression to match whitespace prior to the colon following an update to the format of the AF "ATTESTATION DE DECOMPTE DES NUITEES" document.