### PR TITLE
Bump CI Node version from 22 to 24

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Node 🟢
         uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           cache: npm
 
       - name: Install, build and test 🔧

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Setup Node 🟢
         uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           cache: npm
 
       - name: Install, build and test 🔧


### PR DESCRIPTION
## Summary

- Updates `node-version` in `.github/workflows/release.yml` and `.github/workflows/pr.yml` from `22` to `24`.
- Node 22 entered maintenance LTS in October 2025; Node 24 is the current active LTS until October 2026.
- Avoids deprecation warnings from dependencies that bump their `engines.node` requirement.

## Test plan

- [x] PR Checks workflow runs and passes on Node 24.
- [ ] Next release tag triggers the Release workflow successfully on Node 24.