### PR TITLE
Drop redundant `decimal()` call inside `matchAll` utility

### DIFF
--- a/src/parsers/payParser.js
+++ b/src/parsers/payParser.js
@@ -36,12 +36,12 @@ export const cents2decimal = (cents) => {
 }
 
 // collect first group of all matches
-// returns Array of "decimal"
+// returns Array of strings
 const matchAll = (text, re, bydefault) => {
     const results = [];
     let match;
     while(null !== (match = re.exec(text))) {
-        results.push(decimal(match[1]));
+        results.push(match[1]);
     }
     const found = results.length;
     if (found > 0) {


### PR DESCRIPTION
## Summary
- `matchAll` in `src/parsers/payParser.js` applied `decimal()` to each captured group internally, but every caller already does `.map(decimal)` on the result (or on the next line, like the `net` case).
- `decimal()` is idempotent on already-formatted decimal strings, so the second call was a no-op — but it meant `matchAll` couldn't be reused as a pure regex helper. Dropping the inner call makes the function purely about regex iteration.

No behavioral change.

## Test plan
- [x] `npm test` — 11 suites, 77 tests passing