### PR TITLE
Rename type discriminators and drop AF-era store names

### DIFF
--- a/src/components/DropZone.svelte
+++ b/src/components/DropZone.svelte
@@ -75,7 +75,7 @@
                                     }
                                     if (result.type === "pay") {
                                         Object.assign(batchPaySlips, {[month]: result}); // this method of saving result does not refresh svelte
-                                    }else if (result.type === "ep5") {
+                                    }else if (result.type === "rotations") {
                                         Object.assign(batchEp5, {[month]: result}); // this method of saving result does not refresh svelte
                                     }else if (result.type === "nights") {
                                         $nuiteesAF = result.total;

--- a/src/components/DropZone.svelte
+++ b/src/components/DropZone.svelte
@@ -1,6 +1,6 @@
 <script context="module">
     import { onMount } from "svelte";
-    import { nuiteesAF } from '../stores';
+    import { fraisHebergement } from '../stores';
     import { getPDFTextFromFile, setPdfjsLib } from '../utilities/pdf';
     import loader from "./async-script-loader.js";
     import { Deferred } from "./utils.js";
@@ -13,7 +13,7 @@
 
 <script>
     import { router } from '../parsers/router';
-    import { base, ep5, paySlips, taxData, taxYear, tzConverter } from '../stores';
+    import { base, rotations, paySlips, taxData, taxYear, tzConverter } from '../stores';
     const acceptedType = 'application/pdf';
     let disabled = false; // locally during file processing
     let ready = new Deferred();
@@ -45,7 +45,7 @@
             const promises = [];
             const basename = (file) => file.name.split(/([\\/])/g).pop();
             let batchPaySlips = {};
-            let batchEp5 = {};
+            let batchRotations = {};
             for (let i = 0; i < files.length; i++) {
                 const file = files[i];
                 if (file) {
@@ -76,9 +76,9 @@
                                     if (result.type === "pay") {
                                         Object.assign(batchPaySlips, {[month]: result}); // this method of saving result does not refresh svelte
                                     }else if (result.type === "rotations") {
-                                        Object.assign(batchEp5, {[month]: result}); // this method of saving result does not refresh svelte
+                                        Object.assign(batchRotations, {[month]: result}); // this method of saving result does not refresh svelte
                                     }else if (result.type === "lodging") {
-                                        $nuiteesAF = result.total;
+                                        $fraisHebergement = result.total;
                                     }
                                 }
                             });
@@ -94,10 +94,10 @@
                     return Object.assign(theStore, batchPaySlips);
                 });
                 batchPaySlips = {};
-                ep5.update((theStore) => {
-                    return Object.assign(theStore, batchEp5);
+                rotations.update((theStore) => {
+                    return Object.assign(theStore, batchRotations);
                 });
-                batchEp5 = {};
+                batchRotations = {};
             };
             Promise.all(promises)
                 .then(() => {

--- a/src/components/DropZone.svelte
+++ b/src/components/DropZone.svelte
@@ -77,7 +77,7 @@
                                         Object.assign(batchPaySlips, {[month]: result}); // this method of saving result does not refresh svelte
                                     }else if (result.type === "rotations") {
                                         Object.assign(batchEp5, {[month]: result}); // this method of saving result does not refresh svelte
-                                    }else if (result.type === "nights") {
+                                    }else if (result.type === "lodging") {
                                         $nuiteesAF = result.total;
                                     }
                                 }

--- a/src/components/MonthStatus.svelte
+++ b/src/components/MonthStatus.svelte
@@ -17,7 +17,7 @@
     const computeNameLabel = (requested) => {
         const year = $taxYear;
         if (!year) return name;
-        if (data.type==="ep5") {
+        if (data.type==="rotations") {
             const prev = (parseInt(year, 10) -1).toString();
             const next = (parseInt(year, 10) +1).toString();
             return `${name} de ${monthsfr[11]} ${prev} à ${(requested.length>13) ? monthsfr[0] + ' ' + next : monthsfr[11] + ' ' + year}`;
@@ -26,7 +26,7 @@
         }
     }
     const computeRequestedMonths = (dat) => {
-        if (dat.type==="ep5") {
+        if (dat.type==="rotations") {
             const tz = ($tzConverter)  ? $tzConverter("2020-11-01T00:00Z").slice(-6) : "+01:00";
             let requestedMonthsDefault;
             if (tz === "+00:00") {

--- a/src/components/PayTable.svelte
+++ b/src/components/PayTable.svelte
@@ -1,7 +1,7 @@
 <script>
     import {decimal2cents, cents2decimal} from '../utilities/numbers';
     import {iso2FR} from '../utilities/dates';
-    import { taxYear, taxData, fraisDeMission, nuiteesInput, nuiteesAF, pairings} from '../stores';
+    import { taxYear, taxData, fraisDeMission, fraisHebergementInput, fraisHebergement, pairings} from '../stores';
     import {months, monthsfr, localeCurrency} from './utils';
     import DownloadTablePDF from './DownloadTablePDF.svelte';
     import {fade} from 'svelte/transition';
@@ -29,11 +29,11 @@
         }
         return cents2decimal(total);
     };
-    const updateNuiteesInput = (real, estimated) => {
+    const updateFraisHebergementInput = (real, estimated) => {
         if (real !== undefined) {
-            $nuiteesInput = real;
+            $fraisHebergementInput = real;
         }else if (estimated){
-            $nuiteesInput = estimated;
+            $fraisHebergementInput = estimated;
         }
     }
 
@@ -68,8 +68,8 @@
     $: totalDecouchersFPRO = computeTotalDecouchersFPRO(data);
     $: estimateRatio = ( parseInt($taxYear, 10)  >= 2021) ? 2.7 : 3.31;
     $: nightsCostEstimate = (Math.ceil(parseFloat(totalDecouchersFPRO) * estimateRatio/100) * 100).toFixed(0);
-    $: updateNuiteesInput($nuiteesAF, nightsCostEstimate);
-    $: fraisReels = parseFloat($fraisDeMission) - parseFloat($nuiteesAF || $nuiteesInput || nightsCostEstimate) - parseFloat(totalFrais);
+    $: updateFraisHebergementInput($fraisHebergement, nightsCostEstimate);
+    $: fraisReels = parseFloat($fraisDeMission) - parseFloat($fraisHebergement || $fraisHebergementInput || nightsCostEstimate) - parseFloat(totalFrais);
     $: roadTripInformation = roadTrips($pairings, $taxYear);
 
 </script>
@@ -84,7 +84,7 @@
     <tr>
         <th colspan="3">
             Comparatif {$taxYear}
-            {#if (!$nuiteesInput || $nuiteesInput == nightsCostEstimate)}
+            {#if (!$fraisHebergementInput || $fraisHebergementInput == nightsCostEstimate)}
                 <div class="estimate" transition:fade|local><small>basé sur une estimation des nuitées à ±20%</small></div>
             {/if}
         </th>
@@ -101,9 +101,9 @@
 <tbody>
     <tr>
         <td>
-            <input name="nuitees" type="number" disabled={!!$nuiteesAF} bind:value="{$nuiteesInput}" min="0" step="100" placeholder="{($nuiteesAF) ? $nuiteesAF : nightsCostEstimate}"/>
+            <input name="nuitees" type="number" disabled={!!$fraisHebergement} bind:value="{$fraisHebergementInput}" min="0" step="100" placeholder="{($fraisHebergement) ? $fraisHebergement : nightsCostEstimate}"/>
         </td>
-        <td>{$fraisDeMission} - {parseFloat($nuiteesAF || $nuiteesInput || nightsCostEstimate).toFixed(0)} - {parseFloat(totalFrais).toFixed(0)} = {fraisReels.toFixed(0)} €</td>
+        <td>{$fraisDeMission} - {parseFloat($fraisHebergement || $fraisHebergementInput || nightsCostEstimate).toFixed(0)} - {parseFloat(totalFrais).toFixed(0)} = {fraisReels.toFixed(0)} €</td>
         <td>{abbattement.toFixed(0)} €</td>
     </tr>
 </tbody>

--- a/src/components/SWUpdate.svelte
+++ b/src/components/SWUpdate.svelte
@@ -16,7 +16,7 @@
     };
 </script>
 <script>
-    import {wb, paySlips, ep5, route} from '../stores';
+    import {wb, paySlips, rotations, route} from '../stores';
     import { fade } from 'svelte/transition';
     import ChangeLogModal from '../components/ChangeLogModal.svelte';
     let installLabel = 'Installer';
@@ -61,7 +61,7 @@
     }
 </script>
 
-{#if (($route !== '/' || $majorUpdate) && $swUpdated && !$swDismiss && $ep5.isEmpty() && $paySlips.isEmpty())}
+{#if (($route !== '/' || $majorUpdate) && $swUpdated && !$swDismiss && $rotations.isEmpty() && $paySlips.isEmpty())}
 <div class="modal">
     <div class="toast">   
         <div class="toast-header">
@@ -72,7 +72,7 @@
         </div>
     </div>
 </div>{install(($route === '/') ? 2000 : 700) || ''}
-{:else if $swUpdated && !$swDismiss && (!$ep5.isEmpty() || !$paySlips.isEmpty())}
+{:else if $swUpdated && !$swDismiss && (!$rotations.isEmpty() || !$paySlips.isEmpty())}
     <div class="toast" transition:fade style="position: fixed; top: 0; right: 0;">   
         <div class="toast-header">
             <strong><span>👨🏻‍✈️</span>Mise à jour disponible</strong>

--- a/src/pages/MissionPage.svelte
+++ b/src/pages/MissionPage.svelte
@@ -3,7 +3,7 @@
     import DropZone from '../components/DropZone.svelte';
     import MonthStatus from "../components/MonthStatus.svelte";
     import MissionActivities from '../components/MissionActivities.svelte';
-    import {ep5, base, tzConverter, BASES} from '../stores';
+    import {rotations, base, tzConverter, BASES} from '../stores';
 
     const baseChange = (e) => {
         // we can change base on a month to month basis, so do not empty
@@ -30,12 +30,12 @@
                 Déposez vos <strong>EP5</strong> dans la zone ou Cliquez
             </div>
             <div slot="bottom">
-            <MonthStatus data={$ep5} name="EP5" />
+            <MonthStatus data={$rotations} name="EP5" />
             </div>
         </DropZone>
         <MissionActivities />
     </div>
-    {#if !$ep5.isEmpty()}<Disclaimer/>{/if}
+    {#if !$rotations.isEmpty()}<Disclaimer/>{/if}
 </main>
 <style>
     .header{min-height: 50px}

--- a/src/parsers/airfrance/ep5Parser.js
+++ b/src/parsers/airfrance/ep5Parser.js
@@ -52,7 +52,7 @@ const parseEP5Modern = (text, ctx) => {
     const {month, year} = findEP5Date(text, ctx, MODERN_HEADER_PATTERN);
 
     const result = {
-        type: 'ep5',
+        type: 'rotations',
         date: stampForTaxYear(month, year, ctx.taxYear),
         fileName: ctx.fileName,
         fileOrder: ctx.fileOrder,
@@ -114,7 +114,7 @@ const parseEP5Legacy = (text, ctx) => {
     const {month, year} = findEP5Date(text, ctx, LEGACY_HEADER_PATTERN);
 
     const result = {
-        type: 'ep5',
+        type: 'rotations',
         date: stampForTaxYear(month, year, ctx.taxYear),
         fileName: ctx.fileName,
         fileOrder: ctx.fileOrder,

--- a/src/parsers/airfrance/nightsParser.js
+++ b/src/parsers/airfrance/nightsParser.js
@@ -12,9 +12,9 @@ export const isNuitees = (text) => text.indexOf(ATTESTATION_MARKER) !== -1;
  * Parse an Air France "Attestation de décompte des nuitées" — the
  * annual statement of hotel-night expenses paid by the company.
  *
- * If the document's year doesn't match `ctx.taxYear`, returns the
- * wrong-year error envelope (`type: "nuitées"`); otherwise returns
- * the success envelope with the parsed total.
+ * If the document's year doesn't match `ctx.taxYear`, returns a
+ * `type: "lodging"` envelope carrying an `error`; otherwise returns
+ * the same envelope with the parsed total.
  *
  * @param {string} text
  * @param {import('./index.js').ParserContext} ctx
@@ -27,7 +27,7 @@ export const nightsAFParser = (text, ctx) => {
 
     if (!yearMatch || yearMatch[1] !== taxYear) {
         return [{
-            type: 'nuitées',
+            type: 'lodging',
             error: `année ≠ ${taxYear}`,
             fileName,
             fileOrder,
@@ -36,7 +36,7 @@ export const nightsAFParser = (text, ctx) => {
     }
 
     const result = {
-        type: 'nights',
+        type: 'lodging',
         fileName,
         fileOrder,
         errors: [],

--- a/src/rotations.js
+++ b/src/rotations.js
@@ -266,7 +266,7 @@ export const addIndemnities = (taxYear, rots, taxData, tzConverter, fileName) =>
         } else if  (rot.nights.length > rot.days || rot.countries.length > rot.days) {
             rot.formula = NIGHT_OVERFLOW_TEXT;
             rot.currencyFormula = 'Vérifiez le choix de la base';
-            console.log(`%c${fileName}\n%ctype [ep5] %cVérifiez la base`, 'font-family: monospace;', 'color: black;', 'color: red;');
+            console.log(`%c${fileName}\n%ctype [rotations] %cVérifiez la base`, 'font-family: monospace;', 'color: black;', 'color: red;');
             hasError = true;
         } else {
             // if at least one of the stopover is LC, count all nights
@@ -419,7 +419,7 @@ export const mergeFlights = (flights1, flights2) => {
     return f1.concat(f2);
 };
 
-// Merge rots without needing to copy the EP5/months structure.
+// Merge rots without needing to copy the rotations/months structure.
 export const mergeRots = (data, taxYear, taxData, tzConverter) => {
     const currentIt = Array.isArray(data) ? arrayRotsIterator(data) : monthsRotsIterator(data);
     const nextIt = Array.isArray(data) ? arrayRotsIterator(data) : monthsRotsIterator(data);

--- a/src/stores.js
+++ b/src/stores.js
@@ -74,7 +74,7 @@ export const log = patchLog();
 function isRegisterEmpty () {
     return Object.keys(this).length === 2;
 }
-export const ep5 = resettable({type: "ep5", isEmpty: isRegisterEmpty});
+export const ep5 = resettable({type: "rotations", isEmpty: isRegisterEmpty});
 export const paySlips = resettable({type: "pay", isEmpty: isRegisterEmpty});
 export const nuiteesInput = resettable();
 export const nuiteesAF = resettable();

--- a/src/stores.js
+++ b/src/stores.js
@@ -74,17 +74,17 @@ export const log = patchLog();
 function isRegisterEmpty () {
     return Object.keys(this).length === 2;
 }
-export const ep5 = resettable({type: "rotations", isEmpty: isRegisterEmpty});
+export const rotations = resettable({type: "rotations", isEmpty: isRegisterEmpty});
 export const paySlips = resettable({type: "pay", isEmpty: isRegisterEmpty});
-export const nuiteesInput = resettable();
-export const nuiteesAF = resettable();
+export const fraisHebergementInput = resettable();
+export const fraisHebergement = resettable();
 
 const empty = () => {
-    ep5.reset();
+    rotations.reset();
     paySlips.reset();
     log.reset();
-    nuiteesInput.reset();
-    nuiteesAF.reset();
+    fraisHebergementInput.reset();
+    fraisHebergement.reset();
 }
 
 export const taxYear = writable(defaultYear);
@@ -97,10 +97,10 @@ export const taxData = derived(taxYear, ($taxYear, set) => {
 }, undefined);
 
 export const pairings = derived(
-    [ep5, taxYear, taxData, tzConverter],
-    ([$ep5, $taxYear, $taxData, $tzConverter]) => {
+    [rotations, taxYear, taxData, tzConverter],
+    ([$rotations, $taxYear, $taxData, $tzConverter]) => {
         if ($taxData === undefined) return [];
-        return mergeRots($ep5, $taxYear, $taxData, $tzConverter);
+        return mergeRots($rotations, $taxYear, $taxData, $tzConverter);
     }
 );
 export const fraisDeMission = derived(pairings, $pairings => Object.values($pairings).reduce((a, c) => a + c.indemnity, 0).toFixed(0));

--- a/test/parsers/airfrance.test.js
+++ b/test/parsers/airfrance.test.js
@@ -274,7 +274,7 @@ test('AF legacy EP4 outside the tax year passes through silently', () => {
 test('AF nuitées attestation parsing', () => {
     const text = loadFixture('test/fixtures/af-nuitees.txt');
     expect(router(text, 'af-nuitees.pdf', 0, '2025', taxData, ['CDG', 'ORY'], iso2FR)).toEqual([{
-        type: 'nights',
+        type: 'lodging',
         fileName: 'af-nuitees.pdf',
         fileOrder: 0,
         errors: [],
@@ -287,7 +287,7 @@ test('AF nuitées attestation parsing', () => {
 test('AF legacy nuitées attestation parsing', () => {
     const text = loadFixture('test/fixtures/af-nuitees-legacy.txt');
     expect(router(text, 'af-nuitees-legacy.pdf', 0, '2024', taxData, ['CDG', 'ORY'], iso2FR)).toEqual([{
-        type: 'nights',
+        type: 'lodging',
         fileName: 'af-nuitees-legacy.pdf',
         fileOrder: 0,
         errors: [],
@@ -300,7 +300,7 @@ test('AF legacy nuitées attestation parsing', () => {
 test('AF nuitées attestation for the wrong year surfaces an error', () => {
     const text = loadFixture('test/fixtures/af-nuitees.txt');
     expect(router(text, 'af-nuitees.pdf', 0, '2020', taxData, ['CDG', 'ORY'], iso2FR)).toEqual([{
-        type: 'nuitées',
+        type: 'lodging',
         error: 'année ≠ 2020',
         fileName: 'af-nuitees.pdf',
         fileOrder: 0,

--- a/test/parsers/airfrance.test.js
+++ b/test/parsers/airfrance.test.js
@@ -31,7 +31,7 @@ test('AF payslip parsing', () => {
 test('AF EP5 parsing', () => {
     const text = loadFixture('test/fixtures/af-ep4ep5.txt');
     expect(router(text, 'af-ep4ep5.pdf', 0, '2025', taxData, ['CDG', 'ORY'], iso2FR)).toEqual([{
-        type: 'ep5',
+        type: 'rotations',
         fileName: 'af-ep4ep5.pdf',
         fileOrder: 0,
         date: '2025-10',
@@ -104,7 +104,7 @@ test('AF EP5 parsing', () => {
 test('AF legacy EP5 parsing', () => {
     const text = loadFixture('test/fixtures/af-ep4ep5-legacy.txt');
     expect(router(text, 'af-ep4ep5-legacy.pdf', 0, '2025', taxData, ['CDG', 'ORY'], iso2FR)).toEqual([{
-        type: 'ep5',
+        type: 'rotations',
         fileName: 'af-ep4ep5-legacy.pdf',
         fileOrder: 0,
         date: '2025-07',
@@ -147,7 +147,7 @@ test('AF legacy EP5 parsing', () => {
 test('AF EP5 parsing — December carries over from the previous tax year', () => {
     const text = loadFixture('test/fixtures/af-ep4ep5-dec.txt');
     expect(router(text, 'af-ep4ep5-dec.pdf', 0, '2025', taxData, ['CDG', 'ORY'], iso2FR)).toEqual([{
-        type: 'ep5',
+        type: 'rotations',
         fileName: 'af-ep4ep5-dec.pdf',
         fileOrder: 0,
         date: '2025-00', // Stamped as `${taxYear}-00` so it remains alongside the next year's months.
@@ -181,7 +181,7 @@ test('AF EP5 parsing — December carries over from the previous tax year', () =
 test('AF EP5 parsing — January carries over to the previous tax year', () => {
     const text = loadFixture('test/fixtures/af-ep4ep5-jan.txt');
     expect(router(text, 'af-ep4ep5-jan.pdf', 0, '2025', taxData, ['CDG', 'ORY'], iso2FR)).toEqual([{
-        type: 'ep5',
+        type: 'rotations',
         fileName: 'af-ep4ep5-jan.pdf',
         fileOrder: 0,
         date: '2025-13', // Stamped as `${taxYear}-13` so it remains alongside the previous year's months.
@@ -215,7 +215,7 @@ test('AF EP5 parsing — January carries over to the previous tax year', () => {
 test('AF EP5 outside the tax year is recognized but not parsed', () => {
     const text = loadFixture('test/fixtures/af-ep4ep5.txt');
     expect(router(text, 'af-ep4ep5.pdf', 0, '2020', taxData, ['CDG', 'ORY'], iso2FR)).toEqual([{
-        type: 'ep5',
+        type: 'rotations',
         fileName: 'af-ep4ep5.pdf',
         fileOrder: 0,
         date: '2025-10',


### PR DESCRIPTION
## Summary

Cosmetic-only follow-up to the multi-airline groundwork. Renames a few identifiers that were either AF-document-specific ("EP5") or content-mismatched ("nights" for what's actually a euro amount). Each commit is a focused, mechanical rename — no behavior change.

> [!IMPORTANT]
> Stacked on top of #30; will rebase once merged.

## What's in here

Three commits:

1. **Rename rotation result discriminator: `"ep5"` → `"rotations"`**
   The discriminator named the originating AF document (the EP5 *Carnet de Vol*), not the content. Renaming to `"rotations"` matches what `src/rotations.js` actually produces and makes the envelope shape carrier-agnostic for Transavia. Also fixes the matching `type` field on the store init in `stores.js` and a `[ep5]` debug log tag in `rotations.js`.

2. **Rename lodging result discriminator: `"nights"` → `"lodging"`**
   `"nights"` reads as a count, but the attached `total` is a euro amount — the company-paid "FRAIS D'HEBERGEMENT" total. `"lodging"` describes what the value *is*.

3. **Drop AF qualifiers from lodging stores and the rotations store**
   Three writable stores carried AF-era names that are now redundant:
   ```
   ep5 → rotations
   nuiteesAF → fraisHebergement (parsed from the attestation)
   nuiteesInput → fraisHebergementInput (user-typed override)
   ```

Aligning with the existing `fraisDeMission` naming and with form-2042 vocabulary makes the connection between store and tax document explicit. Local symbols (`batchEp5`, `updateNuiteesInput`) were renamed alongside for consistency.

## Out of scope

- The user-visible `name="EP5"` label on `<MonthStatus>` in `MissionPage.svelte` is intentionally left alone — AF pilots
recognize "EP5" as their carnet de vol, so that's a UX call to make separately (likely once Transavia ships and the same widget needs to label both carriers' data).

## Test plan

- [x] `npm test` — 102 tests passing locally on every commit.
- [x] CI green.
- [x] Manual smoke: drag-and-drop an AF EP5 PDF, an AF payslip, and an AF nuitées attestation into the running app; verify the same monthly aggregation, mission totals, and lodging total as before.