### PR TITLE
Block PDF files from being tracked in the repository

### DIFF
--- a/.github/workflows/block-pdf.yml
+++ b/.github/workflows/block-pdf.yml
@@ -1,0 +1,30 @@
+name: Block PDF
+on:
+  push:
+    branches:
+      - '**'
+  pull_request:
+    branches:
+      - '**'
+jobs:
+  check-no-pdf:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Check no PDF is tracked 🚫
+        run: |
+          PDF_FILES=$(git ls-files '*.pdf')
+          if [ -n "$PDF_FILES" ]; then
+            echo "::error title=PDF files detected::The following PDF files are tracked in the repository and must be removed:"
+            for f in $PDF_FILES; do
+              echo "::error file=${f}::PDF file tracked: ${f}"
+            done
+            exit 1
+          fi
+          echo "No PDF files tracked. ✓"

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 /node_modules/
 public/
 
+*.pdf
+
 .DS_Store
 .env
 workspaceConfiguration/LoadTerminal.json


### PR DESCRIPTION
PDFs in this repo may contain personal data (as noted in .gitignore). This PR extends that protection repo-wide.

### Changes

- **.gitignore** — adds `*.pdf` globally so PDFs are ignored everywhere, not just in fixtures
- **block-pdf.yml** — new workflow that runs on every push and PR to every branch; fails with annotated errors if any PDF is tracked

### Follow-up (manual)

To enforce this server-side on all branches, configure a GitHub Ruleset:
1. **Settings → Rules → Rulesets → New ruleset**
2. Target: all branches (`**`), Enforcement: Active
3. Rule: *Require status checks to pass* → add `check-no-pdf`