### PR TITLE
Fix Cumul inner-error field key in AF payslip parser

### DIFF
--- a/src/parsers/payParser.js
+++ b/src/parsers/payParser.js
@@ -93,7 +93,7 @@ export const payParser = (text, fileName, fileOrder) => {
     try {
         result.cumul = decimal(matchLast(text, /_Annuel_[\-0-9, ]+_{1,2}([\-0-9, ]+)_/g));
     } catch (err) {
-        result.errors.push({"type": "error", "msg":"Cumul Net imposable non trouvé"});
+        result.errors.push({"type": "error", "message":"Cumul Net imposable non trouvé"});
         result.cumul = "0";
     }
     try {


### PR DESCRIPTION
This PR fixes a years-long dormant bug which logged `"undefined"` to the console when a payslip whose `Cumul` line can't be parsed was uploaded.

## Summary

The error pushed to `result.errors` when "Cumul Net imposable" parsing fails uses `msg`, but the convention for inner errors (`result.errors[]`) is `message` — see the surrounding pushes in `payParser.js` and the ones in `nightsAFParser.js`.

The router translates the inner field `error.message` → outer `result.msg` when exploding errors into envelopes (`router.js:14`), so this misnamed inner field had been logging `"undefined"` in the console.

The inner-vs-outer field convention (inner = `message`, outer = `msg`) is otherwise preserved.

## Test plan

- [x] `npm test` — 83 tests pass.
- [x] CI green.