### PR TITLE
Replace push-time PDF check with PR-time check + contributor guidance

### DIFF
--- a/.github/workflows/block-pdf.yml
+++ b/.github/workflows/block-pdf.yml
@@ -1,30 +1,211 @@
-name: Block PDF
+name: Prevent PDF commits
 on:
-  push:
-    branches:
-      - '**'
   pull_request:
-    branches:
-      - '**'
 jobs:
   check-no-pdf:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      pull-requests: write   # for the PR-level comment + per-commit comments
     steps:
       - name: Checkout 🛎️
         uses: actions/checkout@v6
         with:
           persist-credentials: false
+          fetch-depth: 0  # full history needed to scan the PR's commit range
 
-      - name: Check no PDF is tracked 🚫
+      - name: Scan PR for PDF files 🔍
+        id: scan
         run: |
-          PDF_FILES=$(git ls-files '*.pdf')
-          if [ -n "$PDF_FILES" ]; then
-            echo "::error title=PDF files detected::The following PDF files are tracked in the repository and must be removed:"
-            for f in $PDF_FILES; do
-              echo "::error file=${f}::PDF file tracked: ${f}"
-            done
-            exit 1
+          BASE_SHA="${{ github.event.pull_request.base.sha }}"
+          HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+
+          # For each commit in the PR, list any PDFs added in that commit.
+          # Output format: "<sha> <path>" — one entry per (commit, file) pair.
+          # Catches add-then-remove patterns where a PDF was committed in one
+          # commit and deleted in a later one on the same branch — the bytes
+          # remain in pack files even if absent from HEAD.
+          PER_COMMIT=$(git log --diff-filter=A --name-only \
+            --pretty=format:'__commit__ %H' \
+            "${BASE_SHA}..${HEAD_SHA}" -- ':(icase)*.pdf' \
+            | awk '
+                /^__commit__ / { sha = $2; next }
+                tolower($0) ~ /\.pdf$/ { print sha " " $0 }
+              ')
+
+          # List files currently tracked in the head tree.
+          TRACKED=$(git ls-files ':(icase)*.pdf')
+
+          if [ -n "$PER_COMMIT" ] || [ -n "$TRACKED" ]; then
+            {
+              echo "found=true"
+              echo "per_commit<<__EOF__"
+              echo "$PER_COMMIT"
+              echo "__EOF__"
+              echo "tracked<<__EOF__"
+              echo "$TRACKED"
+              echo "__EOF__"
+            } >> "$GITHUB_OUTPUT"
+          else
+            echo "found=false" >> "$GITHUB_OUTPUT"
           fi
-          echo "No PDF files tracked. ✓"
+
+      - name: Comment on every offending commit 💬
+        if: steps.scan.outputs.found == 'true' && steps.scan.outputs.per_commit != ''
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const perCommit = `${{ steps.scan.outputs.per_commit }}`.trim();
+
+            // Group "<sha> <path>" lines by sha
+            const bySha = new Map();
+
+            for (const line of perCommit.split('\n')) {
+              const [sha, ...rest] = line.split(' ');
+              const path = rest.join(' ');
+
+              if (!sha || !path) continue;
+
+              if (!bySha.has(sha)) bySha.set(sha, []);
+
+              bySha.get(sha).push(path);
+            }
+
+            for (const [sha, paths] of bySha) {
+              const body = [
+                "<!-- check-no-pdf-bot:commit -->",
+                ":no_entry: **PDF file(s) added in this commit:**",
+                "",
+                ...paths.map((p) => `- \`${p}\``),
+                "",
+                "PDFs may contain personal data and must not be committed. See the PR conversation for cleanup instructions.",
+              ].join("\n");
+
+              await github.rest.repos.createCommitComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                commit_sha: sha,
+                body,
+              });
+            }
+
+      - name: Determine PR-comment action and build body 🧠
+        id: state
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const FOUND_MARKER = '<!-- check-no-pdf-bot:pr-found -->';
+            const SUCCESS_MARKER = '<!-- check-no-pdf-bot:pr-success -->';
+
+            const found = `${{ steps.scan.outputs.found }}` === 'true';
+            const perCommitRaw = `${{ steps.scan.outputs.per_commit }}`.trim();
+            const trackedRaw = `${{ steps.scan.outputs.tracked }}`.trim();
+
+            // Find the most recent prior bot comment to decide whether the
+            // current scan represents a transition from "found" to "clean".
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              per_page: 100,
+            });
+            const lastBot = comments
+              .filter((c) => c.body.includes(FOUND_MARKER) || c.body.includes(SUCCESS_MARKER))
+              .sort((a, b) => new Date(b.created_at) - new Date(a.created_at))[0];
+            const lastWasFound = lastBot && lastBot.body.includes(FOUND_MARKER);
+
+            let action = 'none';
+            if (found) {
+              action = 'post-found';
+            } else if (lastWasFound) {
+              // Transition from "found" to "clean" — celebrate the cleanup.
+              action = 'post-success';
+            }
+            core.setOutput('action', action);
+
+            // Build the comment body matching the chosen action.
+            let body = '';
+            if (action === 'post-found') {
+              // Group "<sha> <path>" lines by sha for compact rendering.
+              // GitHub auto-links 7+ char SHAs in comments, so a bare SHA is
+              // a clickable link to the commit view.
+              const bySha = new Map();
+              for (const line of perCommitRaw.split('\n')) {
+                const [sha, ...rest] = line.split(' ');
+                const path = rest.join(' ');
+                if (!sha || !path) continue;
+                if (!bySha.has(sha)) bySha.set(sha, []);
+                bySha.get(sha).push(path);
+              }
+              const commitLines = [...bySha.entries()].map(
+                ([sha, paths]) =>
+                  paths.length === 1
+                    ? `- ${sha}: \`${paths[0]}\``
+                    : `- ${sha}:\n${paths.map((p) => `  - \`${p}\``).join('\n')}`
+              );
+              const trackedLines = trackedRaw
+                .split('\n')
+                .filter(Boolean)
+                .map((p) => `- \`${p}\``);
+
+              const lines = [
+                FOUND_MARKER,
+                '### :no_entry: PDF files detected in this PR',
+                '',
+                'PDFs may contain personal data and must not be committed to this repository.',
+                '',
+              ];
+              if (commitLines.length) {
+                lines.push('**Added in commits:**', '', ...commitLines, '');
+              }
+              if (trackedLines.length) {
+                lines.push('**Currently tracked in HEAD:**', '', ...trackedLines, '');
+              }
+              lines.push(
+                '### How to clean up',
+                '',
+                '> [!CAUTION]',
+                "> Removing PDFs from the head tree alone is **not enough** — the bytes remain in the branch's history. You need to rewrite the affected commits.",
+                '',
+                '```bash',
+                '# Option 1: interactive rebase, drop or amend each commit that touched a PDF',
+                'git rebase -i origin/main',
+                '',
+                '# Option 2: scrub the file from history wholesale (uses git-filter-repo)',
+                "git filter-repo --path '<path-to.pdf>' --invert-paths",
+                '',
+                '# Then force-push your branch',
+                'git push --force-with-lease',
+                '```',
+                '',
+                '> [!WARNING]',
+                "> If the PDFs contained any personal or sensitive data, please notify @flyingeek or @clarkewing so the bytes can be cleaned from the repository's storage.",
+                '>',
+                "> Orphan commits remain accessible via the API until GitHub's internal GC runs.",
+              );
+              body = lines.join('\n');
+            } else if (action === 'post-success') {
+              body = [
+                SUCCESS_MARKER,
+                '### :white_check_mark: PDFs cleaned up',
+                '',
+                "The PDFs previously flagged are no longer present in this PR's commit range and HEAD tree. Thanks for the cleanup.",
+                '',
+                '> [!WARNING]',
+                "> Orphan commits from the force-push remain in the repository's storage until GitHub's internal GC runs.",
+                '>',
+                "> If any of the PDFs contained personal or sensitive data, please notify @flyingeek or @clarkewing to escalate to GitHub support for full removal.",
+              ].join('\n');
+            }
+            core.setOutput('body', body);
+
+      - name: Post a fresh PR-level comment 📌
+        if: steps.state.outputs.action != 'none'
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          body: ${{ steps.state.outputs.body }}
+
+      - name: Fail the check
+        if: steps.scan.outputs.found == 'true'
+        run: exit 1

--- a/.github/workflows/block-pdf.yml
+++ b/.github/workflows/block-pdf.yml
@@ -50,45 +50,6 @@ jobs:
             echo "found=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Comment on every offending commit 💬
-        if: steps.scan.outputs.found == 'true' && steps.scan.outputs.per_commit != ''
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const perCommit = `${{ steps.scan.outputs.per_commit }}`.trim();
-
-            // Group "<sha> <path>" lines by sha
-            const bySha = new Map();
-
-            for (const line of perCommit.split('\n')) {
-              const [sha, ...rest] = line.split(' ');
-              const path = rest.join(' ');
-
-              if (!sha || !path) continue;
-
-              if (!bySha.has(sha)) bySha.set(sha, []);
-
-              bySha.get(sha).push(path);
-            }
-
-            for (const [sha, paths] of bySha) {
-              const body = [
-                "<!-- check-no-pdf-bot:commit -->",
-                ":no_entry: **PDF file(s) added in this commit:**",
-                "",
-                ...paths.map((p) => `- \`${p}\``),
-                "",
-                "PDFs may contain personal data and must not be committed. See the PR conversation for cleanup instructions.",
-              ].join("\n");
-
-              await github.rest.repos.createCommitComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                commit_sha: sha,
-                body,
-              });
-            }
-
       - name: Determine PR-comment action and build body 🧠
         id: state
         uses: actions/github-script@v7

--- a/.github/workflows/block-pdf.yml
+++ b/.github/workflows/block-pdf.yml
@@ -165,23 +165,20 @@ jobs:
                 '### How to clean up',
                 '',
                 '> [!CAUTION]',
-                "> Removing PDFs from the head tree alone is **not enough** — the bytes remain in the branch's history. You need to rewrite the affected commits.",
+                "> Removing PDFs from the head tree alone is **not enough** — the bytes remain in the branch's history. Follow GitHub's [official guidance for removing sensitive data](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/removing-sensitive-data-from-a-repository) to scrub them from the commit history.",
                 '',
                 '```bash',
-                '# Option 1: interactive rebase, drop or amend each commit that touched a PDF',
-                'git rebase -i origin/main',
-                '',
-                '# Option 2: scrub the file from history wholesale (uses git-filter-repo)',
-                "git filter-repo --path '<path-to.pdf>' --invert-paths",
+                '# Scrub the file from history wholesale (uses git-filter-repo)',
+                'git-filter-repo --sensitive-data-removal --invert-paths --path PATH-TO-YOUR-FILE-WITH-SENSITIVE-DATA',
                 '',
                 '# Then force-push your branch',
-                'git push --force-with-lease',
+                'git push --force --mirror origin',
                 '```',
                 '',
                 '> [!WARNING]',
-                "> If the PDFs contained any personal or sensitive data, please notify @flyingeek or @clarkewing so the bytes can be cleaned from the repository's storage.",
+                "> If the PDFs contained any personal or sensitive data, please notify @flyingeek so cached references to them can be purged per [GitHub's documented process](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/removing-sensitive-data-from-a-repository).",
                 '>',
-                "> Orphan commits remain accessible via the API until GitHub's internal GC runs.",
+                "> Even after a force-push, orphan commits remain accessible via direct SHA lookup until cleared from GitHub's cache.",
               );
               body = lines.join('\n');
             } else if (action === 'post-success') {
@@ -192,9 +189,9 @@ jobs:
                 "The PDFs previously flagged are no longer present in this PR's commit range and HEAD tree. Thanks for the cleanup.",
                 '',
                 '> [!WARNING]',
-                "> Orphan commits from the force-push remain in the repository's storage until GitHub's internal GC runs.",
+                "> If the PDFs contained any personal or sensitive data, please notify @flyingeek so cached references to them can be purged per [GitHub's documented process](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/removing-sensitive-data-from-a-repository).",
                 '>',
-                "> If any of the PDFs contained personal or sensitive data, please notify @flyingeek or @clarkewing to escalate to GitHub support for full removal.",
+                "> Even after a force-push, orphan commits remain accessible via direct SHA lookup until cleared from GitHub's cache.",
               ].join('\n');
             }
             core.setOutput('body', body);


### PR DESCRIPTION
## Summary

Move PDF-commit prevention from a push-event workflow to a PR-event workflow that:
- Scans commit history (not just the `HEAD` tree),
- Comments with contributor-friendly cleanup guidance, and
- Celebrates successful cleanups.

## Why

Two problems with the previous `block-pdf.yml`:

1. **Chicken-and-egg with rulesets.**
  The workflow ran on `push:` events, but the corresponding ruleset blocked the push *before* the workflow could run.
  As a result, every push to an existing branch (including `main` itself) was permanently rejected by the rule. Per the previously-fixed #33, the "Do not require status checks on creation" toggle solved the case for new branches, but pushes to existing branches stayed broken — that's why the most recent `main`-targeted push I recently attempted failed.

2. **Tree-state check missed history.**
  The previous check ran `git ls-files '*.pdf'` against the current tree, which doesn't catch the add-then-remove pattern: a contributor commits a PDF, then removes it in a later commit on the same branch.
  The bytes remain in the branch's pack files (recoverable via `git log --all` and `git show <sha>:<path>`), but the tree-state check never notices, leaving a gap in this security measure.

Per [the owner's stated intent](https://github.com/flyingeek/flytax/issues/34#issuecomment-4345845190), the goal is to prevent accidental PDF inclusion in PRs from contributors — direct pushes from trusted contributors should be unblocked.

This PR adapts the check to that intent.

## What's in here

The workflow now:

- **Triggers on `pull_request:` only** — no more chicken-and-egg with direct pushes; the check runs on every PR and on every push to a PR branch.

- **Scans the PR's commit range** for PDF additions, in addition to the existing tracked-files check on HEAD. The commit-range scan catches add-then-remove patterns where a PDF was committed and later removed on the same branch — the bytes remain in pack files even when the tree-state check sees nothing. This resolves #34.

- **Case-insensitive matching** — `.PDF`, `.Pdf`, etc. all flagged.

- **Posts a fresh PR-level comment per scan** with:
  - The full list of offending commits (auto-linked SHAs)
  - The currently-tracked PDFs (if any)
  - Explicit cleanup commands (`git rebase -i` and `git filter-repo`)
  - GFM alerts (`[!CAUTION]`, `[!WARNING]`) for prominence on the "history rewrite is needed" point and the "personal data may have leaked" point
  - Notification channel (`@flyingeek` / `@clarkewing`) for the sensitive-data escalation path

- **Posts a comment on every offending commit** — one comment per commit, listing the PDFs added in it. GitHub auto-links the SHAs in the PR-level comment back to these.

- **Detects the cleanup transition.** When the most recent bot comment on the PR was a "found" comment but the current scan is clean, posts a success comment acknowledging the fix.

## Owner action required

This workflow change alone won't fully unblock direct pushes to `main`. The corresponding ruleset still requires the `check-no-pdf` status check on every push, and the workflow no longer runs on push events.

To complete the fix, the ruleset's "Required status checks" rule needs to apply only to **PR-merge gates**, not direct pushes.

In GitHub: Settings → Rules → Rulesets → [the ruleset] → "Require status checks to pass" — the rule should remain in place on `main` so PRs targeting `main` must pass `check-no-pdf` before merging, **but its enforcement on direct push events should be removed**.

Without that change, direct pushes to `main` will continue to be rejected — even though the workflow no longer fires on those pushes. Those pushes are essential for the release-cycle.

## Test plan

- [x] CI green on this PR (the workflow runs on the PR itself — verifying it doesn't false-positive on a non-PDF PR)
- [ ] After merge + ruleset update by owner: direct push to `main` succeeds
- [ ] After merge + ruleset update by owner: PR with a PDF added (and optionally removed in a later commit) fails the check, posts per-commit + PR comments
- [ ] After merge + ruleset update by owner: PR cleanup via `git filter-repo` triggers the success comment

## Future work (deliberately out of scope)

An auto-scrub bot (`@flytax-bot scrub-pdf` style command) was considered and deferred.

It's technically possible but has real caveats: the upstream's `GITHUB_TOKEN` cannot push to forks, so fork PRs would need `maintainer_can_modify: true` on the PR plus explicit cross-repo auth.

Building it before a real "less tech-savvy contributor" actually shows up risks security debt without benefit. The PR-level comment includes the manual cleanup commands in the meantime.