### PR TITLE
Run PR Checks on PRs targeting any branch

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,8 +1,6 @@
 name: PR Checks
 on:
   pull_request:
-    branches:
-      - main
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
This PR fixes an issue where PRs which were opened against a branch other than `main` weren't triggering the `pr.yml` workflow.

It drops the `branches: [main]` filter from `pr.yml` so the workflow runs on every pull request, not just those targeting `main`.

## Test plan

- [x] This PR targets main, so PR Checks should run as before.
- [x] After merge, opening a PR against any non-main base should trigger PR Checks.