### PR TITLE
Document and enforce `package-lock.json` version bump on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,21 +21,28 @@ jobs:
         with:
           validation_level: warn # TODO: Fix issues with CHANGELOG.md before switching from `warn` to `error`
 
-      - name: Verify tag and package.json match CHANGELOG 🔎
+      - name: Verify package.json and CHANGELOG.md versions match tag 🔎
         run: |
           TAG_VERSION="${GITHUB_REF#refs/tags/release/}"
           PKG_VERSION="$(jq -r '.version' package.json)"
+          LOCK_VERSION="$(jq -r '.version' package-lock.json)"
           CHANGELOG_VERSION="${{ steps.changelog.outputs.version }}"
 
           if [ "$PKG_VERSION" != "$TAG_VERSION" ]; then
             LINE=$(grep -n '"version"' package.json | head -1 | cut -d: -f1)
-            echo "::error file=package.json,line=${LINE},title=Version mismatch::package.json version $PKG_VERSION does not match expected tag version $TAG_VERSION"
+            echo "::error file=package.json,line=${LINE},title=Version mismatch::`package.json` version $PKG_VERSION does not match expected tag version $TAG_VERSION"
+            exit 1
+          fi
+
+          if [ "$LOCK_VERSION" != "$TAG_VERSION" ]; then
+            LINE=$(grep -n '"version"' package-lock.json | head -1 | cut -d: -f1)
+            echo "::error file=package-lock.json,line=${LINE},title=Version mismatch::`package-lock.json` version $LOCK_VERSION does not match expected tag version $TAG_VERSION"
             exit 1
           fi
 
           if [ "$CHANGELOG_VERSION" != "$TAG_VERSION" ]; then
             LINE=$(grep -n "^## \[${CHANGELOG_VERSION}\]" CHANGELOG.md | head -1 | cut -d: -f1)
-            echo "::error file=CHANGELOG.md,line=${LINE},title=Version mismatch::Latest CHANGELOG version $CHANGELOG_VERSION does not match expected tag version $TAG_VERSION"
+            echo "::error file=CHANGELOG.md,line=${LINE},title=Version mismatch::Latest `CHANGELOG.md` version $CHANGELOG_VERSION does not match expected tag version $TAG_VERSION"
             exit 1
           fi
 

--- a/README.md
+++ b/README.md
@@ -275,15 +275,21 @@ Pour publier une nouvelle version :
 
 1. Mettre à jour la version dans `package.json`.
 
-2. Ajouter une nouvelle entrée en haut de `CHANGELOG.md` au format `## [X.Y.Z] - YYYY-MM-DD`.
+2. Mettre à jour `package-lock.json` :
 
-3. Créer un commit sur `main` :
+   ```bash
+   npm install --package-lock-only
+   ```
+
+3. Ajouter une nouvelle entrée en haut de `CHANGELOG.md` au format `## [X.Y.Z] - YYYY-MM-DD`.
+
+4. Créer un commit sur `main` :
 
    ```bash
    git commit -am "chore: Bump version X.Y.Z"
    ```
 
-4. Tagger et pousser :
+5. Tagger et pousser :
 
    ```bash
    git tag release/X.Y.Z


### PR DESCRIPTION
## Summary

- Add a step to the release procedure in `README.md` reminding the maintainer to refresh `package-lock.json` (`npm install --package-lock-only`) when bumping the version.
- Extend the `Verify ... versions match tag` job in `.github/workflows/release.yml` to also check `package-lock.json`, so a forgotten lockfile bump fails fast with a clear annotation instead of surfacing later via `npm ci`.
    

## Why

Previously only `package.json` and `CHANGELOG.md` were validated against the release tag. If the lockfile was left behind, the release would still build but ship with an inconsistent version, and the failure mode was opaque.

## Test plan

- [ ] Push a `release/X.Y.Z` tag where `package-lock.json` version disagrees with the tag and confirm the workflow fails at the verify step with a `package-lock.json` annotation.
- [ ] Push a matching tag and confirm the workflow proceeds past the verify step as before.