### PR TITLE
Add foundation for payslip deduplication: identity tags + signature helper

### DIFF
--- a/src/parsers/airfrance/payParser.js
+++ b/src/parsers/airfrance/payParser.js
@@ -29,6 +29,7 @@ export const payParser = (text, ctx) => {
 
     const result = {
         type: 'pay',
+        airline: 'AF',
         fileName,
         fileOrder,
         errors: [],

--- a/src/parsers/airfrance/payParser.js
+++ b/src/parsers/airfrance/payParser.js
@@ -50,6 +50,17 @@ export const payParser = (text, ctx) => {
     }
 
     try {
+        result.paymentDate = matchLast(text, PAYMENT_DATE_RE).split('/').reverse().join('-');
+    } catch (err) {
+        result.paymentDate = '';
+
+        result.errors.push({
+            type: 'error',
+            message: 'Date de paiement non trouvée',
+        });
+    }
+
+    try {
         const net = matchAll(text, NET_RE);
 
         result.imposable = sum(net.map(decimal));
@@ -96,6 +107,7 @@ export const payParser = (text, ctx) => {
 };
 
 const DATE_RE = /PERIODE DU \d{2}\/(\d{2}\/\d{4})/g;
+const PAYMENT_DATE_RE = /PAYE LE\s*:\s*(\d{2}\/\d{2}\/\d{4})/g;
 const NET_RE = /_Mensuel_[\-0-9, ]+_{1,2}([\-0-9, ]+)_/g;
 const CUMUL_RE = /_Annuel_[\-0-9, ]+_{1,2}([\-0-9, ]+)_/g;
 const REPAS_RE = /(?:IND\.REPAS_+|INDEMNITE REPAS_+|IR\.FIN ANNEE DOUBL_+|IR EXONEREES_+|IR NON EXONEREES_+)([\-0-9, ]+)/g;

--- a/src/utilities/payslips.js
+++ b/src/utilities/payslips.js
@@ -1,0 +1,22 @@
+/**
+ * Create a stable identity signature for a parsed payslip result.
+ *
+ * Two payslips are considered the same iff they share the same airline,
+ * payment date, and net imposable. Re-importing the same PDF — or the
+ * same payslip exported under a different filename — produces the same
+ * signature, so downstream consumers can deduplicate on insert.
+ *
+ * Payment date (`YYYY-MM-DD`) is used rather than the period date
+ * (`YYYY-MM`) because it's strictly more discriminating: it distinguishes
+ * two bulletins covering the same period but issued on different days
+ * (e.g. multiple complémentaires for the same month).
+ *
+ * @example
+ *   payslipSignature({airline: 'AF', paymentDate: '2025-11-30', imposable: '8811.55'})
+ *   // → "AF|2025-11-30|8811.55"
+ *
+ * @param {{airline: string, paymentDate: string, imposable: string}} payslip
+ * @returns {string}
+ */
+export const payslipSignature = (payslip) =>
+    `${payslip.airline}|${payslip.paymentDate}|${payslip.imposable}`;

--- a/test/parsers/airfrance.test.js
+++ b/test/parsers/airfrance.test.js
@@ -20,6 +20,7 @@ test('AF payslip parsing', () => {
         fileOrder: 0,
         errors: [],
         date: '2025-11',
+        paymentDate: '2025-11-30',
         imposable: '8811.55',
         cumul: '56644.85',
         repas: ['526.36'],

--- a/test/parsers/airfrance.test.js
+++ b/test/parsers/airfrance.test.js
@@ -15,6 +15,7 @@ test('AF payslip parsing', () => {
     const text = loadFixture('test/fixtures/af-payslip.txt');
     expect(router(text, 'af-payslip.pdf', 0, '2025', taxData, ['CDG', 'ORY'], iso2FR)).toEqual([{
         type: 'pay',
+        airline: 'AF',
         fileName: 'af-payslip.pdf',
         fileOrder: 0,
         errors: [],

--- a/test/utilities/payslips.test.js
+++ b/test/utilities/payslips.test.js
@@ -1,0 +1,57 @@
+import { payslipSignature } from '../../src/utilities/payslips';
+
+test("payslipSignature combines airline, paymentDate, and imposable", () => {
+    expect(payslipSignature({
+        airline: 'AF',
+        paymentDate: '2025-11-30',
+        imposable: '8811.55',
+    })).toBe('AF|2025-11-30|8811.55');
+});
+
+test("payslipSignature ignores fields outside its identity contract", () => {
+    const a = payslipSignature({
+        airline: 'AF',
+        paymentDate: '2025-11-30',
+        imposable: '8811.55',
+        date: '2025-11',
+        fileName: 'af-payslip.pdf',
+        fileOrder: 0,
+        cumul: '56644.85',
+        errors: [],
+        repas: ['526.36'],
+    });
+    const b = payslipSignature({
+        airline: 'AF',
+        paymentDate: '2025-11-30',
+        imposable: '8811.55',
+        date: '2025-11',
+        fileName: 'renamed.pdf',
+        fileOrder: 7,
+        cumul: '99999.99',
+        errors: [{type: 'error', message: 'boom'}],
+        repas: [],
+    });
+
+    expect(a).toBe(b);
+});
+
+test("payslipSignature distinguishes different airlines for the same payment date and amount", () => {
+    const af = payslipSignature({airline: 'AF', paymentDate: '2026-04-30', imposable: '4500.00'});
+    const to = payslipSignature({airline: 'TO', paymentDate: '2026-04-30', imposable: '4500.00'});
+
+    expect(af).not.toBe(to);
+});
+
+test("payslipSignature distinguishes different payment dates within the same period", () => {
+    const a = payslipSignature({airline: 'AF', paymentDate: '2026-04-15', imposable: '4500.00'});
+    const b = payslipSignature({airline: 'AF', paymentDate: '2026-04-22', imposable: '4500.00'});
+
+    expect(a).not.toBe(b);
+});
+
+test("payslipSignature distinguishes different imposable amounts", () => {
+    const a = payslipSignature({airline: 'AF', paymentDate: '2025-11-30', imposable: '8811.55'});
+    const b = payslipSignature({airline: 'AF', paymentDate: '2025-11-30', imposable: '8811.56'});
+
+    expect(a).not.toBe(b);
+});


### PR DESCRIPTION
## Summary

Foundational PR for the multi-payslip / deduplication work outlined in #45. Three small, sequential additions:

1. **Tag AF payslip results with `airline: 'AF'`** — mirrors the existing `airline` tag on rotations (added in 30e3986). Carries provenance through to downstream consumers without reaching back to the parser identity. Anticipates multiple payslips from different airlines for the same month.

2. **Extract `paymentDate` from AF payslips** — surfaces the payment date as a separate field on the result, in `YYYY-MM-DD` form. The existing `date` field stays as `YYYY-MM` for monthly grouping in `PayTable`; `paymentDate` is the more discriminating sibling used for identity. Failure to extract is non-fatal.

3. **`src/utilities/payslips.js` with `payslipSignature(payslip)`** — pure helper returning a canonical `airline|paymentDate|imposable` string. Two payslips collide on signature if and only if they describe the same payslip.

No consumer yet — the deduplication site lands in the upcoming paySlips store migration.

## Test plan

- [x] `npm test` — 124 passing (+5 over `main`, all for `payslipSignature`)
- [x] `npm run build` — clean
- [x] PR Checks workflow runs on this branch