### PR TITLE
Migrate `paySlips` and `rotations` to flat-array stores

### DIFF
--- a/src/components/DropZone.svelte
+++ b/src/components/DropZone.svelte
@@ -46,7 +46,7 @@
             const promises = [];
             const basename = (file) => file.name.split(/([\\/])/g).pop();
             let batchPaySlips = [...$paySlips.items];
-            let batchRotations = {};
+            let batchRotations = [...$rotations.items];
             for (let i = 0; i < files.length; i++) {
                 const file = files[i];
                 if (file) {
@@ -81,7 +81,14 @@
                                         }
                                         batchPaySlips.push(result);
                                     }else if (result.type === "rotations") {
-                                        Object.assign(batchRotations, {[month]: result}); // this method of saving result does not refresh svelte
+                                        // Replace any existing rotations stamped to the same
+                                        // tax-year month (re-importing an EP5 supersedes the
+                                        // previous one); flatten the envelope's rotations
+                                        // into the store.
+                                        batchRotations = [
+                                            ...batchRotations.filter(r => r.taxDate !== result.date),
+                                            ...result.rots,
+                                        ];
                                     }else if (result.type === "lodging") {
                                         $fraisHebergement = result.total;
                                     }
@@ -96,10 +103,7 @@
                 disabled = false;
                 if (target) target.value = null; // reset file input
                 paySlips.update((theStore) => ({...theStore, items: batchPaySlips}));
-                rotations.update((theStore) => {
-                    return Object.assign(theStore, batchRotations);
-                });
-                batchRotations = {};
+                rotations.update((theStore) => ({...theStore, items: batchRotations}));
             };
             Promise.all(promises)
                 .then(() => {

--- a/src/components/DropZone.svelte
+++ b/src/components/DropZone.svelte
@@ -14,6 +14,7 @@
 <script>
     import { router } from '../parsers/router';
     import { base, rotations, paySlips, taxData, taxYear, tzConverter } from '../stores';
+    import { findIn, payslipSignature } from '../utilities/payslips';
     const acceptedType = 'application/pdf';
     let disabled = false; // locally during file processing
     let ready = new Deferred();
@@ -44,7 +45,7 @@
         await ready.promise.then(() => {
             const promises = [];
             const basename = (file) => file.name.split(/([\\/])/g).pop();
-            let batchPaySlips = {};
+            let batchPaySlips = [...$paySlips.items];
             let batchRotations = {};
             for (let i = 0; i < files.length; i++) {
                 const file = files[i];
@@ -74,7 +75,11 @@
                                         return;
                                     }
                                     if (result.type === "pay") {
-                                        Object.assign(batchPaySlips, {[month]: result}); // this method of saving result does not refresh svelte
+                                        if (findIn(batchPaySlips, result)) {
+                                            console.log(`%c${fileName}\n%ctype [pay] %cDoublon ignoré (${payslipSignature(result)})`, 'font-family: monospace;', 'color: black;', 'color: darkorange;');
+                                            return;
+                                        }
+                                        batchPaySlips.push(result);
                                     }else if (result.type === "rotations") {
                                         Object.assign(batchRotations, {[month]: result}); // this method of saving result does not refresh svelte
                                     }else if (result.type === "lodging") {
@@ -90,10 +95,7 @@
             const afterLoad = () => {
                 disabled = false;
                 if (target) target.value = null; // reset file input
-                paySlips.update((theStore) => {
-                    return Object.assign(theStore, batchPaySlips);
-                });
-                batchPaySlips = {};
+                paySlips.update((theStore) => ({...theStore, items: batchPaySlips}));
                 rotations.update((theStore) => {
                     return Object.assign(theStore, batchRotations);
                 });

--- a/src/components/MonthStatus.svelte
+++ b/src/components/MonthStatus.svelte
@@ -1,84 +1,155 @@
 <script>
-    import {months, monthsfr} from "./utils";
-    import {taxYear, tzConverter} from '../stores';
-    import {loadedMonths} from '../utilities/payslips';
+    import { taxYear, tzConverter } from '../stores';
+    import { tzOffset } from '../utilities/dates';
+    import { loadedMonths } from '../utilities/payslips';
+    import { months, monthsfr } from "./utils";
+
     export let data = [];
     export let name = "Mois";
-    let nameLabel;
-    const label = (month) => {
-        switch(month) {
-            case "13":
-                return "01"
-            case "00":
-                return "12"
-            default:
-                return month;
+
+
+    /**
+     * Display string for a tax-year month code.
+     *
+     * @param {string} month - 2-digit tax-year stamp ("00"–"13").
+     * @returns {string} 2-digit calendar month ("01"–"12").
+     */
+    const monthLabel = (month) => {
+        switch (month) {
+            case "13": return "01";
+            case "00": return "12";
+            default:   return month;
         }
     };
-    const computeNameLabel = (requested) => {
-        const year = $taxYear;
-        if (!year) return name;
-        if (data.type==="rotations") {
-            const prev = (parseInt(year, 10) -1).toString();
-            const next = (parseInt(year, 10) +1).toString();
-            return `${name} de ${monthsfr[11]} ${prev} à ${(requested.length>13) ? monthsfr[0] + ' ' + next : monthsfr[11] + ' ' + year}`;
-        } else {
-            return `${name} de ${monthsfr[0]} ${year} à ${monthsfr[11]} ${year}`;
-        }
-    }
-    const computeRequestedMonths = (dat) => {
-        if (dat.type==="rotations") {
-            const tz = ($tzConverter)  ? $tzConverter("2020-11-01T00:00Z").slice(-6) : "+01:00";
-            let requestedMonthsDefault;
-            if (tz === "+00:00") {
-                requestedMonthsDefault = months.map(m => [m, true]);
-            }else if (tz[0] === '+'){
-                requestedMonthsDefault = ['00', ...months].map(m => [m, true]); // TODO this is the only one working in the logic below
-            }else {
-                requestedMonthsDefault = [...months, '13'].map(m => [m, true]);
-            }
-            let requested = [];
-            if (dat.isEmpty()) {
-                requested = [...requestedMonthsDefault];
-            }else{
-                for (let i=0; i < 14; i++) {
-                    const m = i.toString().padStart(2, '0');
-                    const n = (i + 1).toString().padStart(2, '0');
-                    const p = (i - 1).toString().padStart(2, '0');
-                    if (dat[n]&& dat[n].rots && dat[n].rots.length > 0 && dat[n].rots[0].isComplete===">"){
-                        requested.push([m, false]);
-                    }else if (dat[p] && dat[p].rots && dat[p].rots.length > 0 && dat[p].rots[dat[p].rots.length - 1].isComplete==="<"){
-                        requested.push([m, false]);
-                    }else if (i!==13){
-                        requested.push([m, true]);
-                    }else if (i===13 && dat[m] !== undefined){
-                        requested.push([m, true]); 
-                    }
-                }
-            }
-            nameLabel = computeNameLabel(requested);
-            return requested;
-        }else{
-            nameLabel = computeNameLabel();
-            return months.map(m => [m, false]);
-        }
+
+
+    /**
+     * Whether month `month` is partnered with a straddler boundary in its
+     * adjacent months — i.e. a rotation crossing a month boundary has its
+     * `<` or `>` half in `month`'s neighbor.
+     *
+     * @param {Object<string, Array<{isComplete: string}>>} byMonth
+     * @param {string} month
+     * @returns {boolean}
+     */
+    const isStraddlerBoundary = (byMonth, month) => {
+        const i = parseInt(month, 10);
+        const nextMonth = (i + 1).toString().padStart(2, '0');
+        const prevMonth = (i - 1).toString().padStart(2, '0');
+
+        return byMonth[nextMonth]?.[0]?.isComplete === '>'
+            || byMonth[prevMonth]?.at(-1)?.isComplete === '<';
     };
-    $: requestedMonths = computeRequestedMonths(data);
-    // Months populated with at least one entry. Computed once per `data`
-    // change so the template doesn't need to know which shape carries the
-    // payload (rotations: month-keyed object; payslips: flat `items` array).
-    $: monthsLoaded = (data.type === "pay")
-        ? loadedMonths(data.items ?? [])
-        : new Set(Object.keys(data).filter(k => /^\d{2}$/.test(k)));
+
+
+    /**
+     * Slots to display by default when the rotations register is empty.
+     * Heuristic based on the base's UTC offset (read from `$tzConverter`
+     * in component scope).
+     *
+     * @returns {Array<string>}
+     */
+    const defaultEmptySlots = () => {
+        const offset = tzOffset($tzConverter);
+
+        if (offset === "+00:00") return months;
+        if (offset[0] === '+') return ['00', ...months];
+
+        return [...months, '13'];
+    };
+
+
+    /**
+     * The list of month tiles to display, each tagged with whether the
+     * month is "optional" or "required".
+     *
+     * @param {{type: string, items?: Array<object>, isEmpty: () => boolean}} register
+     * @returns {Array<[string, boolean]>} Each entry is `[month, isOptional]`.
+     */
+    const computeRequestedMonths = (register) => {
+        const REQUIRED = false;
+        const OPTIONAL = true;
+
+        if (register.type !== "rotations") {
+            return months.map((month) => [month, REQUIRED]);
+        }
+
+        if (register.isEmpty()) {
+            return defaultEmptySlots().map((month) => [month, OPTIONAL]);
+        }
+
+        // Bucket rotations by their stamped tax-year month for the
+        // boundary checks.
+        const byMonth = {};
+        for (const rot of register.items) {
+            (byMonth[rot.taxDate.split('-')[1]] ??= []).push(rot);
+        }
+
+        // Slot 00 is always present; slot 13 only if it has data or
+        // slot 12 has a trailing `<` half.
+        const slots = ['00', ...months];
+        if (byMonth['13'] || byMonth['12']?.at(-1)?.isComplete === '<') {
+            slots.push('13');
+        }
+
+        return slots.map((month) =>
+            [month, isStraddlerBoundary(byMonth, month) ? REQUIRED : OPTIONAL]
+        );
+    };
+
+
+    /**
+     * Build the panel's header text.
+     *
+     * @param {Array<[string, boolean]>} requested - Output of `computeRequestedMonths`.
+     * @returns {string}
+     */
+    const computeHeader = (requested) => {
+        if (!$taxYear) return name;
+
+        if (data.type === "rotations") {
+            const prev = (parseInt($taxYear, 10) - 1).toString();
+            const next = (parseInt($taxYear, 10) + 1).toString();
+            const tail = (requested.length > 13)
+                ? `${monthsfr[0]} ${next}`
+                : `${monthsfr[11]} ${$taxYear}`;
+
+            return `${name} de ${monthsfr[11]} ${prev} à ${tail}`;
+        }
+
+        return `${name} de ${monthsfr[0]} ${$taxYear} à ${monthsfr[11]} ${$taxYear}`;
+    };
+
+
+    // The `($tzConverter, …)` comma-operator pattern ensures `$tzConverter`
+    // is a tracked dependency of this reactive block.
+    $: requestedMonths = ($tzConverter, computeRequestedMonths(data));
+    $: header = computeHeader(requestedMonths);
+
+    // Months populated with at least one entry. Both stores share the
+    // same `items` array shape; rotations carry their stamped month on
+    // `taxDate` (vs. payslips' `date` for the period month).
+    $: monthsLoaded = (data.type === "rotations")
+        ? loadedMonths(data.items, (rot) => rot.taxDate)
+        : loadedMonths(data.items);
 </script>
+
+
 <div>
-    <div>{nameLabel}<slot></slot></div>
+    <div>{header}<slot></slot></div>
+
     <ul>
-    {#each requestedMonths as [month, optional]}
-    <li class:loaded="{monthsLoaded.has(month)}" class:optional="{optional === true}">{label(month)}</li>
-    {/each}
+        {#each requestedMonths as [month, optional]}
+            <li
+                class:loaded="{monthsLoaded.has(month)}"
+                class:optional="{optional === true}"
+            >
+                {monthLabel(month)}
+            </li>
+        {/each}
     </ul>
 </div>
+
 
 <style>
     ul {
@@ -86,6 +157,7 @@
         margin: 0.5em 0 0 0;
         padding: 0;
     }
+
     li {
         --size: 2em;
         display: inline-block;
@@ -94,14 +166,16 @@
         height: var(--size);
         line-height: var(--size);
         text-align: center;
-        background-color:var(--redaf);
+        background-color: var(--redaf);
         color: var(--white);
         margin: 2px 5px;
     }
+
     li.loaded {
         background-color: var(--green) !important;
     }
+
     li.optional {
-        background-color: var(--color);/*orange;*/
+        background-color: var(--color); /*orange;*/
     }
 </style>

--- a/src/components/MonthStatus.svelte
+++ b/src/components/MonthStatus.svelte
@@ -1,6 +1,7 @@
 <script>
     import {months, monthsfr} from "./utils";
     import {taxYear, tzConverter} from '../stores';
+    import {loadedMonths} from '../utilities/payslips';
     export let data = [];
     export let name = "Mois";
     let nameLabel;
@@ -63,12 +64,18 @@
         }
     };
     $: requestedMonths = computeRequestedMonths(data);
+    // Months populated with at least one entry. Computed once per `data`
+    // change so the template doesn't need to know which shape carries the
+    // payload (rotations: month-keyed object; payslips: flat `items` array).
+    $: monthsLoaded = (data.type === "pay")
+        ? loadedMonths(data.items ?? [])
+        : new Set(Object.keys(data).filter(k => /^\d{2}$/.test(k)));
 </script>
 <div>
     <div>{nameLabel}<slot></slot></div>
     <ul>
     {#each requestedMonths as [month, optional]}
-    <li class:loaded="{data[month] !== undefined}" class:optional="{optional === true}">{label(month)}</li>
+    <li class:loaded="{monthsLoaded.has(month)}" class:optional="{optional === true}">{label(month)}</li>
     {/each}
     </ul>
 </div>

--- a/src/components/PayTable.svelte
+++ b/src/components/PayTable.svelte
@@ -1,34 +1,53 @@
 <script>
-    import {decimal2cents, cents2decimal} from '../utilities/numbers';
-    import {iso2FR} from '../utilities/dates';
-    import { taxYear, taxData, fraisDeMission, fraisHebergementInput, fraisHebergement, pairings} from '../stores';
-    import {months, monthsfr, localeCurrency} from './utils';
+    import { fade } from 'svelte/transition';
+    import { fraisDeMission, fraisHebergement, fraisHebergementInput, pairings, taxData, taxYear } from '../stores';
+    import { iso2FR } from '../utilities/dates';
+    import { cents2decimal, decimal2cents } from '../utilities/numbers';
+    import { groupByMonth } from '../utilities/payslips';
     import DownloadTablePDF from './DownloadTablePDF.svelte';
-    import {fade} from 'svelte/transition';
+    import { localeCurrency, months, monthsfr } from './utils';
 
     export let data;
     export let tableId="PayTable";
-    const computeTotalImposable = (data) => {
-        let total = 0;
-        for (const month of months) {
-            total += (data[month]) ? decimal2cents(data[month].imposable) : 0;
-        }
-        return cents2decimal(total);
+
+    /**
+     * Sum decimal-string fields across a list of bulletins, in cents.
+     *
+     * @example
+     *   sumOver(items, b => [b.imposable])                 // total imposable in cents
+     *   sumOver(items, b => [...b.repas, ...b.transport])  // frais d'emploi in cents
+     *   sumOver(items, b => b.decouchers_fpro)             // découchers in cents
+     *
+     * @param {Array<object>} bulletins
+     * @param {(bulletin: object) => Array<string>} getValues
+     * @returns {number}
+     */
+    const sumOver = (bulletins, getValues) => bulletins
+            .flatMap(getValues)
+            .reduce((acc, d) => acc + decimal2cents(d), 0);
+
+    /**
+     * The YTD cumul reported across `bulletins`, as a decimal string.
+     *
+     * @example
+     *   cumulOf([{cumul: '56644.85'}, {cumul: '0'}])  // → "56644.85"
+     *   cumulOf([{cumul: '0'}])                        // → undefined
+     *   cumulOf([])                                    // → undefined
+     *
+     * @param {Array<{cumul: string}>} bulletins
+     * @returns {string | undefined}
+     */
+    const cumulOf = (bulletins) => {
+        const cents = Math.max(
+            0,
+            ...bulletins.map(b => decimal2cents(b.cumul)),
+        );
+
+        return cents > 0
+            ? cents2decimal(cents)
+            : undefined;
     };
-    const computeTotalFrais = (data) => {
-        let total = 0;
-        for (const month of months) {
-            total += (data[month]) ? sumFrais(month) : 0;
-        }
-        return cents2decimal(total);
-    };
-    const computeTotalDecouchersFPRO = (data) => {
-        let total = 0;
-        for (const month of months) {
-            total += (data[month]) ? data[month].decouchers_fpro.map(decimal2cents).reduce((a, b) => a + b): 0;
-        }
-        return cents2decimal(total);
-    };
+
     const updateFraisHebergementInput = (real, estimated) => {
         if (real !== undefined) {
             $fraisHebergementInput = real;
@@ -37,9 +56,6 @@
         }
     }
 
-    const sumFrais = (month) => {
-        return data[month].repas.concat(data[month].transport).map(decimal2cents).reduce((a, b) => a + b);
-    };
     const roadTrips = (pairings, taxYear) => {
         if (!pairings || !taxYear) return '';
         const results = {'count': pairings.length, 'OUT': new Map(), 'IN': new Map()};
@@ -61,11 +77,12 @@
         return `À titre d'information, pour les frais de transport, les ${results.count} rotations représentent ${to.join(', ')} et ${from.join(', ')}.`;
     }
 
-    $: totalFrais = computeTotalFrais(data);
-    $: totalImposable = computeTotalImposable(data);
-    $: cumulImposable12 = (data["12"] && data["12"].cumul !== "0") ? cents2decimal(decimal2cents(data["12"].cumul)) : undefined;
+    $: byMonth = groupByMonth(data.items);
+    $: totalFrais = cents2decimal(sumOver(data.items, b => [...b.repas, ...b.transport]));
+    $: totalImposable = cents2decimal(sumOver(data.items, b => [b.imposable]));
+    $: cumulImposable12 = cumulOf(byMonth["12"] ?? []);
     $: abbattement = ($taxData && $taxData.maxForfait10) ? Math.min((cumulImposable12||totalImposable)*0.1, $taxData.maxForfait10) : 0;
-    $: totalDecouchersFPRO = computeTotalDecouchersFPRO(data);
+    $: totalDecouchersFPRO = cents2decimal(sumOver(data.items, b => b.decouchers_fpro));
     $: estimateRatio = ( parseInt($taxYear, 10)  >= 2021) ? 2.7 : 3.31;
     $: nightsCostEstimate = (Math.ceil(parseFloat(totalDecouchersFPRO) * estimateRatio/100) * 100).toFixed(0);
     $: updateFraisHebergementInput($fraisHebergement, nightsCostEstimate);
@@ -130,12 +147,14 @@
     </thead>
     <tbody>
         {#each months as month, i}
+            {@const bulletins = byMonth[month] ?? []}
+            {@const cumul = cumulOf(bulletins)}
             <tr>
                 <td>{monthsfr[i]}</td>
-                <td>{(data[month]) ? localeCurrency(data[month].imposable) : ""}</td>
-                <td>{(data[month]) ? localeCurrency(data[month].cumul) : ""}</td>
-                <td>{(data[month]) ? localeCurrency(cents2decimal(sumFrais(month))) : ""}</td>
-                <td>{(data[month]) ? localeCurrency(data[month].decouchers_fpro) : ""}</td>
+                <td>{bulletins.length ? localeCurrency(cents2decimal(sumOver(bulletins, b => [b.imposable]))) : ""}</td>
+                <td>{cumul ? localeCurrency(cumul) : ""}</td>
+                <td>{bulletins.length ? localeCurrency(cents2decimal(sumOver(bulletins, b => [...b.repas, ...b.transport]))) : ""}</td>
+                <td>{bulletins.length ? localeCurrency(cents2decimal(sumOver(bulletins, b => b.decouchers_fpro))) : ""}</td>
             </tr>
         {/each}
         <tr>

--- a/src/parsers/airfrance/ep5Parser.js
+++ b/src/parsers/airfrance/ep5Parser.js
@@ -87,7 +87,7 @@ const parseEP5Modern = (text, ctx) => {
         });
     }
 
-    result.rots = buildAFRotations(flights, ctx);
+    result.rots = buildAFRotations(flights, ctx, result.date);
 
     return result;
 };
@@ -137,7 +137,7 @@ const parseEP5Legacy = (text, ctx) => {
         });
     }
 
-    result.rots = buildAFRotations(flights, ctx);
+    result.rots = buildAFRotations(flights, ctx, result.date);
 
     return result;
 };
@@ -154,7 +154,7 @@ const sortFlights = (flights) => flights.sort((a, b) => {
     return c === 0 ? a.end.localeCompare(b.end) : c;
 });
 
-const buildAFRotations = (flights, ctx) => {
+const buildAFRotations = (flights, ctx, taxDate) => {
     const rots = buildRots(
         sortFlights(flights),
         {
@@ -165,7 +165,8 @@ const buildAFRotations = (flights, ctx) => {
         },
     );
 
-    return addIndemnities(ctx.taxYear, rots, ctx.taxData, ctx.tzConverter, ctx.fileName);
+    return addIndemnities(ctx.taxYear, rots, ctx.taxData, ctx.tzConverter, ctx.fileName)
+        .map((rot) => ({...rot, taxDate}));
 };
 
 /**

--- a/src/rotations.js
+++ b/src/rotations.js
@@ -1,7 +1,7 @@
-import {localeFormat, months14} from "./components/utils";
-import {lastDayInMonthISO, numberOfDays, diffHours} from './utilities/dates';
-import {iata2country} from './utilities/iata';
-import {findAmountEuros, findAmount, AmountError} from './utilities/indemnity';
+import { localeFormat } from "./components/utils";
+import { diffHours, lastDayInMonthISO, numberOfDays } from './utilities/dates';
+import { iata2country } from './utilities/iata';
+import { AmountError, findAmount, findAmountEuros } from './utilities/indemnity';
 
 export const WITHIN_BASE_TEXT = "rotation sur base";
 export const NIGHT_OVERFLOW_TEXT = "Erreur: nuitées > nb de jours";
@@ -388,23 +388,6 @@ export const addIndemnities = (taxYear, rots, taxData, tzConverter, fileName) =>
     return results;
 };
 
-// Iterates rots stored in a {monthKey: {rots: [...]}} structure (months14-keyed).
-export function* monthsRotsIterator(data) {
-    for (const m of months14) {
-        const monthData = data[m];
-        if (monthData) {
-            yield* monthData.rots;
-        }
-    }
-}
-
-// In tests we pass rots as a plain array.
-export function* arrayRotsIterator(data) {
-    for (const a of data) {
-        yield* a;
-    }
-}
-
 export const mergeFlights = (flights1, flights2) => {
     const f1 = [...flights1];
     const f2 = [...flights2];
@@ -419,24 +402,71 @@ export const mergeFlights = (flights1, flights2) => {
     return f1.concat(f2);
 };
 
-// Merge rots without needing to copy the rotations/months structure.
-export const mergeRots = (data, taxYear, taxData, tzConverter) => {
-    const currentIt = Array.isArray(data) ? arrayRotsIterator(data) : monthsRotsIterator(data);
-    const nextIt = Array.isArray(data) ? arrayRotsIterator(data) : monthsRotsIterator(data);
-    nextIt.next();
-    const mergedRots = [];
-    for (const rot of currentIt) {
-        const next = nextIt.next().value;
-        if (next && rot.isComplete === '<' && next.isComplete === '>' && rot.end.substring(0, 7) === next.end.substring(0, 7)) {
-            const [merged] = buildRots(mergeFlights(rot.flights, next.flights), {base: rot.base, tzConverter, "iataMap": iata2country, "airline": rot.airline});
-            const [mergedWithIndemnities] = addIndemnities(taxYear, [merged], taxData, tzConverter);
-            mergedRots.push(mergedWithIndemnities);
-            // skip next
-            currentIt.next();
-            nextIt.next();
-        } else {
-            mergedRots.push(rot);
-        }
-    }
-    return mergedRots;
-};
+/**
+ * Determine whether two adjacent rotations are two halves of one straddler.
+ *
+ * @param {{isComplete: string, end: string} | undefined} rot
+ * @param {{isComplete: string, end: string} | undefined} next
+ * @returns {boolean}
+ */
+const mergeable = (rot, next) =>
+    rot
+    && next
+    && rot.isComplete === '<'
+    && next.isComplete === '>'
+    && rot.end.substring(0, 7) === next.end.substring(0, 7);
+
+/**
+ * Sort rotations chronologically by `start` and `isComplete`.
+ *
+ * Returns a new array; the input is not mutated.
+ *
+ * @example
+ *   sortRots([
+ *     {start: '2025-10-31T23:59+01:00', isComplete: '>'},
+ *     {start: '2025-10-31T23:59+01:00', isComplete: '<'},
+ *   ])
+ *   // → [<-half first, >-half second]
+ *
+ * @param {Array<{start: string, isComplete: string}>} rots
+ * @returns {Array<object>}
+ */
+export const sortRots = (rots) => [...rots].sort((a, b) => {
+    const c = a.start.localeCompare(b.start);
+    return c !== 0 ? c : a.isComplete.localeCompare(b.isComplete);
+});
+
+/**
+ * Reunite rotations split across month boundaries.
+ *
+ * Implementation note: the reduce is a forward pass that looks backward
+ * at what was just emitted. When the previous entry's tail can mate with
+ * the current item, the previous entry is replaced by the merged
+ * rotation rather than the current one being pushed — so the second half
+ * is implicitly absorbed. The merged result is `<>` (complete), so
+ * subsequent iterations never re-merge it.
+ *
+ * @param {Array<object>} rots - Flat array of rotations, any order.
+ * @param {string} taxYear - 4-digit year of the declaration, e.g. `"2025"`.
+ * @param {object} taxData
+ * @param {function} tzConverter
+ * @returns {Array<object>}
+ */
+export const mergeRots = (rots, taxYear, taxData, tzConverter) =>
+    sortRots(rots).reduce((acc, rot) => {
+        const prevRot = acc[acc.length - 1];
+
+        if (!mergeable(prevRot, rot)) return [...acc, rot];
+
+        const [withIndemnities] = addIndemnities(
+            taxYear,
+            buildRots(
+                mergeFlights(prevRot.flights, rot.flights),
+                {base: prevRot.base, tzConverter, iataMap: iata2country, airline: prevRot.airline},
+            ),
+            taxData,
+            tzConverter,
+        );
+
+        return [...acc.slice(0, -1), withIndemnities];
+    }, []);

--- a/src/stores.js
+++ b/src/stores.js
@@ -1,6 +1,6 @@
-import { writable, readable, derived } from 'svelte/store';
-import {iso2FR, iso2AST} from './utilities/dates';
-import {mergeRots} from './rotations';
+import { derived, readable, writable } from 'svelte/store';
+import { mergeRots } from './rotations';
+import { iso2AST, iso2FR } from './utilities/dates';
 
 export const BASES = [
     {label: "Marseille", selected: false, value: ['MRS'], tzConverter: iso2FR},
@@ -75,7 +75,11 @@ function isRegisterEmpty () {
     return Object.keys(this).length === 2;
 }
 export const rotations = resettable({type: "rotations", isEmpty: isRegisterEmpty});
-export const paySlips = resettable({type: "pay", isEmpty: isRegisterEmpty});
+export const paySlips = resettable({
+    type: "pay",
+    items: [],
+    isEmpty() { return this.items.length === 0; },
+});
 export const fraisHebergementInput = resettable();
 export const fraisHebergement = resettable();
 

--- a/src/stores.js
+++ b/src/stores.js
@@ -71,15 +71,13 @@ const patchLog = () => {
 }
 
 export const log = patchLog();
-function isRegisterEmpty () {
-    return Object.keys(this).length === 2;
-}
-export const rotations = resettable({type: "rotations", isEmpty: isRegisterEmpty});
-export const paySlips = resettable({
-    type: "pay",
+const register = (type) => ({
+    type,
     items: [],
     isEmpty() { return this.items.length === 0; },
 });
+export const rotations = resettable(register("rotations"));
+export const paySlips = resettable(register("pay"));
 export const fraisHebergementInput = resettable();
 export const fraisHebergement = resettable();
 
@@ -104,7 +102,7 @@ export const pairings = derived(
     [rotations, taxYear, taxData, tzConverter],
     ([$rotations, $taxYear, $taxData, $tzConverter]) => {
         if ($taxData === undefined) return [];
-        return mergeRots($rotations, $taxYear, $taxData, $tzConverter);
+        return mergeRots($rotations.items, $taxYear, $taxData, $tzConverter);
     }
 );
 export const fraisDeMission = derived(pairings, $pairings => Object.values($pairings).reduce((a, c) => a + c.indemnity, 0).toFixed(0));

--- a/src/utilities/dates.js
+++ b/src/utilities/dates.js
@@ -107,6 +107,25 @@ export const iso2FR = iso2TZ.bind(null, "Europe/Paris");
 export const iso2AST = iso2TZ.bind(null, "America/Puerto_Rico");
 
 /**
+ * Extract the UTC offset string from a tz-converter function (e.g.
+ * {@link iso2FR} or {@link iso2AST}). Probes the converter with a
+ * northern-hemisphere winter date to avoid DST ambiguity.
+ *
+ * Falls back to `"+01:00"` (Paris winter) when no converter is given.
+ *
+ * @example
+ *   tzOffset(iso2FR)         // → "+01:00" (probe is Nov 1, no DST)
+ *   tzOffset(iso2AST)        // → "-04:00"
+ *   tzOffset(undefined)      // → "+01:00"
+ *
+ * @param {((iso: string) => string) | null | undefined} tzConverter
+ * @returns {string} Offset like `"+01:00"`, `"-04:00"`, or `"+00:00"`.
+ */
+export const tzOffset = (tzConverter) => tzConverter
+    ? tzConverter("2020-11-01T00:00Z").slice(-6)
+    : "+01:00";
+
+/**
  * Convert a Paris-local wall-clock time to a UTC ISO timestamp.
  * Inverse of {@link iso2FR} for typical inputs.
  *

--- a/src/utilities/payslips.js
+++ b/src/utilities/payslips.js
@@ -20,3 +20,54 @@
  */
 export const payslipSignature = (payslip) =>
     `${payslip.airline}|${payslip.paymentDate}|${payslip.imposable}`;
+
+/**
+ * Group an array of payslips by their period month (`"01"`–`"12"`),
+ * extracted from the `YYYY-MM` `date` field.
+ *
+ * @example
+ *   groupByMonth([{date: '2025-11', ...}, {date: '2025-11', ...}, {date: '2025-12', ...}])
+ *   // → { "11": [{...}, {...}], "12": [{...}] }
+ *
+ * @param {Array<{date: string}>} items
+ * @returns {Object<string, Array<object>>}
+ */
+export const groupByMonth = (payslips) => {
+    const out = {};
+
+    for (const payslip of payslips) (out[payslip.date.split('-')[1]] ??= []).push(payslip);
+
+    return out;
+};
+
+/**
+ * Find a payslip in `payslips` that shares its identity signature.
+ *
+ * Returns the matching payslip or `undefined` if none.
+ *
+ * @example
+ *   findIn(store.items, parsedResult)  // → existing payslip, or undefined
+ *
+ * @param {Array<object>} payslips
+ * @param {object} candidate
+ * @returns {object | undefined}
+ */
+export const findIn = (payslips, candidate) => {
+    const sig = payslipSignature(candidate);
+
+    return payslips.find((payslip) => payslipSignature(payslip) === sig);
+};
+
+/**
+ * Set of period months (`"01"`–`"12"`) for which `items` carries at
+ * least one entry — extracted from each item's `YYYY-MM` `date` field.
+ *
+ * @example
+ *   loadedMonths([{date: '2025-11', ...}, {date: '2025-12', ...}, {date: '2025-11', ...}])
+ *   // → Set { "11", "12" }
+ *
+ * @param {Array<{date: string}>} items
+ * @returns {Set<string>}
+ */
+export const loadedMonths = (items) =>
+    new Set(items.map((b) => b.date.split('-')[1]));

--- a/src/utilities/payslips.js
+++ b/src/utilities/payslips.js
@@ -59,15 +59,22 @@ export const findIn = (payslips, candidate) => {
 };
 
 /**
- * Set of period months (`"01"`–`"12"`) for which `items` carries at
- * least one entry — extracted from each item's `YYYY-MM` `date` field.
+ * Set of months for which `items` carries at least one entry — extracted
+ * from a `YYYY-MM…` field on each item via `getDate`.
+ *
+ * Defaults to reading each item's `date` field, used by paySlips
+ * (`"YYYY-MM"`, the period month). Rotations pass `r => r.taxDate` so
+ * they read the tax-year-stamped month (`"YYYY-00"`–`"YYYY-13"`) instead.
  *
  * @example
- *   loadedMonths([{date: '2025-11', ...}, {date: '2025-12', ...}, {date: '2025-11', ...}])
+ *   loadedMonths([{date: '2025-11'}, {date: '2025-12'}, {date: '2025-11'}])
  *   // → Set { "11", "12" }
+ *   loadedMonths([{taxDate: '2025-00'}], (r) => r.taxDate)
+ *   // → Set { "00" }
  *
- * @param {Array<{date: string}>} items
+ * @param {Array<object>} items
+ * @param {(item: object) => string} [getDate]
  * @returns {Set<string>}
  */
-export const loadedMonths = (items) =>
-    new Set(items.map((b) => b.date.split('-')[1]));
+export const loadedMonths = (items, getDate = (b) => b.date) =>
+    new Set(items.map((item) => getDate(item).split('-')[1]));

--- a/test/parsers/airfrance.test.js
+++ b/test/parsers/airfrance.test.js
@@ -52,6 +52,7 @@ test('AF EP5 parsing', () => {
                 currencyFormula: '3 x 490USD',
                 indemnity: 1330.8,
                 error: false,
+                taxDate: '2025-10',
             },
             {
                 isComplete: '<>',
@@ -67,6 +68,7 @@ test('AF EP5 parsing', () => {
                 currencyFormula: '5 x 200EUR',
                 indemnity: 1000,
                 error: false,
+                taxDate: '2025-10',
             },
             {
                 isComplete: '<>',
@@ -82,6 +84,7 @@ test('AF EP5 parsing', () => {
                 currencyFormula: '3 x 360USD',
                 indemnity: 977.73,
                 error: false,
+                taxDate: '2025-10',
             },
             {
                 isComplete: '<>',
@@ -97,6 +100,7 @@ test('AF EP5 parsing', () => {
                 currencyFormula: '3 x 490USD',
                 indemnity: 1330.8,
                 error: false,
+                taxDate: '2025-10',
             },
         ],
     }]);
@@ -125,6 +129,7 @@ test('AF legacy EP5 parsing', () => {
                 currencyFormula: '3 x 360USD',
                 indemnity: 977.73,
                 error: false,
+                taxDate: '2025-07',
             },
             {
                 isComplete: '<>',
@@ -140,6 +145,7 @@ test('AF legacy EP5 parsing', () => {
                 currencyFormula: '3 x 137000XOF',
                 indemnity: 626.58,
                 error: false,
+                taxDate: '2025-07',
             },
         ],
     }]);
@@ -174,6 +180,7 @@ test('AF EP5 parsing — December carries over from the previous tax year', () =
                 currencyFormula: '',
                 indemnity: 0,
                 error: false,
+                taxDate: '2025-00',
             },
         ],
     }]);
@@ -208,6 +215,7 @@ test('AF EP5 parsing — January carries over to the previous tax year', () => {
                 currencyFormula: '',
                 indemnity: 0,
                 error: false,
+                taxDate: '2025-13',
             },
         ],
     }]);

--- a/test/rotations/memento13.test.js
+++ b/test/rotations/memento13.test.js
@@ -91,7 +91,7 @@ test("memento13 mergeRots #1", () => {
     //expect(rots2[0].stays).toEqual([]);
     const originalLog = console.log;
     console.log = jest.fn();
-    let rots = mergeRots([rots1, rots2], "2019", taxData, iso2FR);
+    let rots = mergeRots([rots1, rots2].flat(), "2019", taxData, iso2FR);
     expect(console.log.mock.calls[0][0].startsWith('Optimisation')).toBeTruthy();
     console.log = originalLog;
     expect(rots.length).toBe(1);
@@ -114,7 +114,7 @@ test("memento13 mergeRots #2", () => {
     //expect(rots2[0].stays).toEqual([]);
     const originalLog = console.log;
     console.log = jest.fn();
-    let rots = mergeRots([rots1, rots2], "2019", taxData, iso2FR);
+    let rots = mergeRots([rots1, rots2].flat(), "2019", taxData, iso2FR);
     expect(console.log.mock.calls[0][0].startsWith('Optimisation')).toBeTruthy();
     console.log = originalLog;
     expect(rots.length).toBe(1);
@@ -138,7 +138,7 @@ test("memento13 mergeRots #3", () => {
     //expect(rots2[0].stays).toEqual(['HKG']);
     const originalLog = console.log;
     console.log = jest.fn();
-    let rots = mergeRots([rots1, rots2], "2019", taxData, iso2FR);
+    let rots = mergeRots([rots1, rots2].flat(), "2019", taxData, iso2FR);
     expect(console.log.mock.calls[0][0].startsWith('Optimisation')).toBeTruthy();
     console.log = originalLog;
     expect(rots.length).toBe(1);
@@ -163,7 +163,7 @@ test("memento13 mergeRots #4", () => {
     expect(rots2[0].nights).toEqual(['HKG', 'HKG', 'HKG', 'HKG']);
     const originalLog = console.log;
     console.log = jest.fn();
-    let rots = mergeRots([rots1, rots2], "2019", taxData, iso2FR);
+    let rots = mergeRots([rots1, rots2].flat(), "2019", taxData, iso2FR);
     expect(console.log.mock.calls[0][0].startsWith('Optimisation')).toBeTruthy();
     console.log = originalLog;
     expect(rots.length).toBe(1);
@@ -186,7 +186,7 @@ test("memento13 mergeRots #5", () => {
     //expect(rots2[0].stays).toEqual(['DXB', 'HKG', 'HKG']);
     const originalLog = console.log;
     console.log = jest.fn();
-    let rots = mergeRots([rots1, rots2], "2019", taxData, iso2FR);
+    let rots = mergeRots([rots1, rots2].flat(), "2019", taxData, iso2FR);
     expect(console.log.mock.calls[0][0].startsWith('Optimisation')).toBeTruthy();
     console.log = originalLog;
     expect(rots.length).toBe(1);
@@ -211,7 +211,7 @@ test("memento13 with dxb next day mergeRots #1", () => {
     //expect(rots2[0].stays).toEqual(['DXB', 'HKG', 'HKG']);
     const originalLog = console.log;
     console.log = jest.fn();
-    let rots = mergeRots([rots1, rots2], "2019", taxData, iso2FR);
+    let rots = mergeRots([rots1, rots2].flat(), "2019", taxData, iso2FR);
     expect(console.log.mock.calls.length).toBe(0);
     console.log = originalLog;
     expect(rots.length).toBe(1);

--- a/test/rotations/sortRots.test.js
+++ b/test/rotations/sortRots.test.js
@@ -1,0 +1,51 @@
+import {sortRots} from '../../src/rotations';
+
+const rot = (start, isComplete = '<>') => ({start, isComplete});
+
+test("sortRots orders rotations chronologically by start", () => {
+    const a = rot('2025-10-04T11:03+02:00');
+    const b = rot('2025-10-18T15:13+02:00');
+    const c = rot('2025-11-01T08:00+01:00');
+
+    expect(sortRots([c, a, b])).toEqual([a, b, c]);
+});
+
+test("sortRots ties on start: '<' precedes '>' so straddler halves stay adjacent", () => {
+    const startHalf = rot('2025-10-31T23:59+01:00', '<');
+    const endHalf   = rot('2025-10-31T23:59+01:00', '>');
+
+    expect(sortRots([endHalf, startHalf])).toEqual([startHalf, endHalf]);
+});
+
+test("sortRots ties on start: lexical order on isComplete (`<` < `<>` < `>`)", () => {
+    const t = '2025-10-31T23:59+01:00';
+    const begin = rot(t, '<');
+    const full  = rot(t, '<>');
+    const end   = rot(t, '>');
+
+    expect(sortRots([end, full, begin])).toEqual([begin, full, end]);
+});
+
+test("sortRots returns a new array without mutating the input", () => {
+    const a = rot('2025-10-18T15:13+02:00');
+    const b = rot('2025-10-04T11:03+02:00');
+    const input = [a, b];
+
+    const sorted = sortRots(input);
+
+    expect(input).toEqual([a, b]);          // input untouched
+    expect(sorted).toEqual([b, a]);         // result is sorted
+    expect(sorted).not.toBe(input);         // not the same reference
+});
+
+test("sortRots returns an empty array for an empty input", () => {
+    expect(sortRots([])).toEqual([]);
+});
+
+test("sortRots is stable across multiple distinct months", () => {
+    const dec = rot('2024-12-31T15:33+01:00', '<');
+    const jan = rot('2026-01-01T01:00+01:00', '>');
+    const jun = rot('2025-06-15T08:00+02:00', '<>');
+
+    expect(sortRots([jan, jun, dec])).toEqual([dec, jun, jan]);
+});

--- a/test/rotations/straddling.test.js
+++ b/test/rotations/straddling.test.js
@@ -15,7 +15,7 @@ test('mergeRots', () => {
     let rots1 = buildRots(flights1, {"base": ["CDG", "ORY"], "tzConverter": iso2FR, "iataMap": iata2country});
     let rots2 = buildRots(flights2, {"base": ["CDG", "ORY"], "tzConverter": iso2FR, "iataMap": iata2country});
 
-    let rots = mergeRots([rots1, rots2], "2019", taxData, iso2FR);
+    let rots = mergeRots([rots1, rots2].flat(), "2019", taxData, iso2FR);
     expect(rots[0]).toEqual({
         isComplete: '<>',
         error: false,
@@ -69,7 +69,7 @@ test("2 ON SVO BOD straddling check not MC", () => {
     expect(rots2[0].arr).toBe('CDG');
     rots2 = addIndemnities("2019", rots2, taxData, iso2FR);
     
-    let rots = mergeRots([rots1, rots2], "2019", taxData, iso2FR);
+    let rots = mergeRots([rots1, rots2].flat(), "2019", taxData, iso2FR);
     expect(rots[0]).toEqual({
         isComplete: '<>',
         error: false,
@@ -103,7 +103,7 @@ test("attempts successive merge to check results does not change", () => {
     let rots2 = buildRots(flights2, {"base": ["CDG", "ORY"], "tzConverter": iso2FR, "iataMap": iata2country});
     rots2 = addIndemnities("2019", rots2, taxData, iso2FR);
     
-    let rots = mergeRots([rots1, rots2], "2019", taxData, iso2FR);
+    let rots = mergeRots([rots1, rots2].flat(), "2019", taxData, iso2FR);
     const expected = {
         isComplete: '<>',
         error: false,
@@ -123,7 +123,7 @@ test("attempts successive merge to check results does not change", () => {
     //
     // Try a second time, check that results are the same, otherwise there is a deep clone failure somewhere
     //
-    rots = mergeRots([rots1, rots2], "2019", taxData, iso2FR);
+    rots = mergeRots([rots1, rots2].flat(), "2019", taxData, iso2FR);
     expect(rots[0]).toEqual(expected);
 });
 
@@ -233,7 +233,7 @@ test("2 ON SVO BOD straddling years check not MC for 2020", () => {
     
     let rots2 = buildRots(flights2, {"base": ["CDG", "ORY"], "tzConverter": iso2FR, "iataMap": iata2country});
     rots2 = addIndemnities("2020", rots2, taxData, iso2FR);
-    let rots = mergeRots([rots1, rots2], "2020", taxData, iso2FR);
+    let rots = mergeRots([rots1, rots2].flat(), "2020", taxData, iso2FR);
     expect(rots[0]).toEqual({
         isComplete: '<>',
         error: false,
@@ -264,7 +264,7 @@ test("2 ON SVO BOD straddling years check for 2019", () => {
     
     let rots2 = buildRots(flights2, {"base": ["CDG", "ORY"], "tzConverter": iso2FR, "iataMap": iata2country});
     rots2 = addIndemnities("2019", rots2, taxData, iso2FR);
-    let rots = mergeRots([rots1, rots2], "2019", taxData, iso2FR);
+    let rots = mergeRots([rots1, rots2].flat(), "2019", taxData, iso2FR);
     expect(rots[0]).toEqual({
         isComplete: '<>',
         error: false,
@@ -325,7 +325,7 @@ test("7ON SVO du soir", () => {
     expect(rots2[0].dep).toBe(CONTINUATION_MARK);
     expect(rots2[0].arr).toBe('CDG');
 
-    let rots = mergeRots([rots1, rots2], "2019", taxData, iso2FR);
+    let rots = mergeRots([rots1, rots2].flat(), "2019", taxData, iso2FR);
     expect(rots.length).toBe(1);
     expect(rots[0]).toEqual({
         isComplete: '<>',
@@ -356,7 +356,7 @@ test("2ON SVO check 0,00 CDG straddling", () => {
     ];
     let rots1 = buildRots(flights1, {"base": ["CDG", "ORY"], "tzConverter": iso2FR, "iataMap": iata2country});
     let rots2 = buildRots(flights2, {"base": ["CDG", "ORY"], "tzConverter": iso2FR, "iataMap": iata2country});
-    let rots = mergeRots([rots1, rots2], "2019", taxData, iso2FR);
+    let rots = mergeRots([rots1, rots2].flat(), "2019", taxData, iso2FR);
     rots = addIndemnities("2019", rots, taxData, iso2FR);
     expect(rots.length).toBe(1);
     expect(rots[0]).toEqual({
@@ -388,7 +388,7 @@ test("2ON SVO check 0,00 SVO straddling", () => {
     ];
     let rots1 = buildRots(flights1, {"base": ["CDG", "ORY"], "tzConverter": iso2FR, "iataMap": iata2country});
     let rots2 = buildRots(flights2, {"base": ["CDG", "ORY"], "tzConverter": iso2FR, "iataMap": iata2country});
-    let rots = mergeRots([rots1, rots2], "2019", taxData, iso2FR);
+    let rots = mergeRots([rots1, rots2].flat(), "2019", taxData, iso2FR);
     rots = addIndemnities("2019", rots, taxData, iso2FR);
     expect(rots.length).toBe(1);
     expect(rots[0]).toEqual({
@@ -469,7 +469,7 @@ test("single day rotation, last straddling flight of an EP5 with a base arrival 
     expect(rots2[0].summary).toBe(CONTINUATION_MARK + 'BOD-CDG');
     expect(rots2[0].dep).toBe(CONTINUATION_MARK);
     expect(rots2[0].arr).toBe('CDG');
-    let rots = mergeRots([rots1, rots2], "2019", taxData, iso2FR);
+    let rots = mergeRots([rots1, rots2].flat(), "2019", taxData, iso2FR);
     expect(rots[0]).toEqual({
         isComplete: '<>',
         error: false,
@@ -522,6 +522,6 @@ test('ludovic 30on madrid', ()=> {
     ];
     let rots1 = buildRots(flights1, {"base": ["CDG", "ORY"], "tzConverter": iso2FR, "iataMap": iata2country});
     let rots2 = buildRots(flights2, {"base": ["CDG", "ORY"], "tzConverter": iso2FR, "iataMap": iata2country});
-    let rots = mergeRots([rots1, rots2], "2020", taxData, iso2FR);
+    let rots = mergeRots([rots1, rots2].flat(), "2020", taxData, iso2FR);
     expect(rots[0].days).toBe(2); // was 30
 });

--- a/test/utilities/dates.test.js
+++ b/test/utilities/dates.test.js
@@ -1,6 +1,6 @@
 import {
     decimalHours2iso, diffHours, fr2iso, iso2AST, iso2FR, iso2TZ,
-    lastDayInMonthISO, numberOfDays,
+    lastDayInMonthISO, numberOfDays, tzOffset,
 } from '../../src/utilities/dates';
 
 test("lastDayInMonthISO", () => {
@@ -107,4 +107,23 @@ test("fr2iso", () => {
     // Round-trip with iso2FR
     expect(iso2FR(fr2iso("2025-03-19", "14:24"))).toBe("2025-03-19T14:24+01:00");
     expect(iso2FR(fr2iso("2025-07-19", "14:24"))).toBe("2025-07-19T14:24+02:00");
+});
+
+test("tzOffset extracts the offset from iso2FR (Paris, no DST in November)", () => {
+    expect(tzOffset(iso2FR)).toBe("+01:00");
+});
+
+test("tzOffset extracts the offset from iso2AST (PTP, year-round AST)", () => {
+    expect(tzOffset(iso2AST)).toBe("-04:00");
+});
+
+test("tzOffset works with a custom converter function", () => {
+    const utcConverter = (iso) => iso.replace("Z", "+00:00");
+
+    expect(tzOffset(utcConverter)).toBe("+00:00");
+});
+
+test("tzOffset falls back to '+01:00' when no converter is provided", () => {
+    expect(tzOffset(undefined)).toBe("+01:00");
+    expect(tzOffset(null)).toBe("+01:00");
 });

--- a/test/utilities/payslips.test.js
+++ b/test/utilities/payslips.test.js
@@ -1,4 +1,6 @@
-import { payslipSignature } from '../../src/utilities/payslips';
+import { findIn, groupByMonth, loadedMonths, payslipSignature } from '../../src/utilities/payslips';
+
+// payslipSignature
 
 test("payslipSignature combines airline, paymentDate, and imposable", () => {
     expect(payslipSignature({
@@ -54,4 +56,76 @@ test("payslipSignature distinguishes different imposable amounts", () => {
     const b = payslipSignature({airline: 'AF', paymentDate: '2025-11-30', imposable: '8811.56'});
 
     expect(a).not.toBe(b);
+});
+
+
+// groupByMonth
+
+test("groupByMonth groups payslips by their period month", () => {
+    const nov = {date: '2025-11', airline: 'AF', imposable: '8000.00'};
+    const dec = {date: '2025-12', airline: 'AF', imposable: '9000.00'};
+    const novBis = {date: '2025-11', airline: 'TO', imposable: '500.00'};
+
+    expect(groupByMonth([nov, dec, novBis])).toEqual({
+        '11': [nov, novBis],
+        '12': [dec],
+    });
+});
+
+test("groupByMonth preserves insertion order within each month", () => {
+    const a = {date: '2025-11', imposable: '1000.00'};
+    const b = {date: '2025-11', imposable: '2000.00'};
+    const c = {date: '2025-11', imposable: '3000.00'};
+
+    expect(groupByMonth([a, b, c])).toEqual({'11': [a, b, c]});
+    expect(groupByMonth([b, a, c])).toEqual({'11': [b, a, c]});
+});
+
+test("groupByMonth returns an empty object for an empty array", () => {
+    expect(groupByMonth([])).toEqual({});
+});
+
+
+// findIn
+
+test("findIn returns the existing payslip whose signature matches the candidate", () => {
+    const a = {airline: 'AF', paymentDate: '2025-11-30', imposable: '8811.55'};
+    const b = {airline: 'AF', paymentDate: '2025-12-31', imposable: '9000.00'};
+    const candidate = {...a, fileName: 'reupload.pdf'};
+
+    expect(findIn([a, b], candidate)).toBe(a);
+});
+
+test("findIn returns undefined when no signature matches", () => {
+    const a = {airline: 'AF', paymentDate: '2025-11-30', imposable: '8811.55'};
+    const candidate = {airline: 'AF', paymentDate: '2025-12-31', imposable: '9000.00'};
+
+    expect(findIn([a], candidate)).toBeUndefined();
+});
+
+test("findIn returns undefined for an empty array", () => {
+    const candidate = {airline: 'AF', paymentDate: '2025-11-30', imposable: '8811.55'};
+
+    expect(findIn([], candidate)).toBeUndefined();
+});
+
+
+// loadedMonths
+
+test("loadedMonths returns the set of period months represented in items", () => {
+    expect(loadedMonths([
+        {date: '2025-11'},
+        {date: '2025-12'},
+        {date: '2025-11'},
+    ])).toEqual(new Set(['11', '12']));
+});
+
+test("loadedMonths returns an empty Set for an empty array", () => {
+    expect(loadedMonths([])).toEqual(new Set());
+});
+
+test("loadedMonths deduplicates months that appear multiple times", () => {
+    const items = Array.from({length: 5}, () => ({date: '2025-04'}));
+
+    expect(loadedMonths(items)).toEqual(new Set(['04']));
 });

--- a/test/utilities/payslips.test.js
+++ b/test/utilities/payslips.test.js
@@ -129,3 +129,21 @@ test("loadedMonths deduplicates months that appear multiple times", () => {
 
     expect(loadedMonths(items)).toEqual(new Set(['04']));
 });
+
+test("loadedMonths reads from a custom field via the optional getter", () => {
+    // Rotations carry their stamped tax-year month on `taxDate` rather
+    // than `date`, including boundary stamps "00" / "13".
+    expect(loadedMonths([
+        {taxDate: '2025-00'},
+        {taxDate: '2025-06'},
+        {taxDate: '2025-13'},
+    ], (r) => r.taxDate)).toEqual(new Set(['00', '06', '13']));
+});
+
+test("loadedMonths getter is consulted per item", () => {
+    // Sanity-check that the getter actually runs against each item rather
+    // than being baked into a closure over the first one.
+    const items = [{a: '2025-01'}, {a: '2025-02'}, {a: '2025-03'}];
+
+    expect(loadedMonths(items, (item) => item.a)).toEqual(new Set(['01', '02', '03']));
+});


### PR DESCRIPTION
PR 3 of the multi-bulletin / deduplication roadmap (#45).

Stacks on top of #47  (`payslip-signature-and-airline-tag`); will rebase onto `main` once that lands.

Replaces the month-keyed object shapes for both `paySlips` and `rotations` with a flat-array shape. Both stores now share the same contract:

```js
{type: "pay" | "rotations", items: [...], isEmpty}
```

…where each item is the unit of data (a bulletin or a rotation). This makes multi-bulletin months possible and unifies the two stores' shapes for v2.0 multi-company integration.

## Two commits, two halves

The migration unfolds in two coherent steps. Each commit is independently testable.

### 1. `paySlips` → flat array of payslips, deduplicated by signature

- Store: `{type: "pay", items: [...bulletin], isEmpty}`
- DropZone aggregation switches from `Object.assign(theStore, {[month]: result})` to append-with-dedup via `findIn(items, candidate)` against `payslipSignature` (`airline | paymentDate | imposable`).
- Re-importing the same PDF — or a renamed copy — drops the second result with a console warning. Importing two distinct payslips for the same month keeps both.
- New helpers in `src/utilities/payslips.js`:
  - `groupByMonth(items)` — buckets paylips by their period month
  - `findIn(items, candidate)` — looks up an existing entry sharing the candidate's signature
  - `loadedMonths(items, getDate?)` — set of months represented in `items`, with optional getter for stores using a different field
- `PayTable.svelte` aggregations replaced with two local helpers:
  - `sumOver(payslips, getValues)` — covers imposable / frais / découchers via `flatMap` + reduce
  - `cumulOf(payslips)` — returns the YTD cumul as a decimal string (or undefined for no usable cumul, treating corrective bulletins with `cumul: "0"` as discarded)
- `MonthStatus.svelte` drops its inline reactive expression in favor of `loadedMonths`.

The visible UI is unchanged: months still render as a single row with summed values; cumul takes the max across same-month payslips so corrective ones don't clobber the YTD figure. Per-payslip row rendering for multi-payslip months — the visible UI delta @flyingeek agreed to — lands in PR 4.

### 2. `rotations` → flat array of rotations, mirroring `paySlips`

Each rotation now carries its own tax-year-stamped month on a new `taxDate` field, set by the parser at parse time. The EP5 envelope's `date`, `fileName`, `fileOrder` were incidental nesting — a holdover from the EP5-per-month parsing convention, not properties of the rotation data itself.

Consumer changes:

- **`ep5Parser`** (modern + legacy): stamps each rotation with `taxDate` inside `buildAFRotations` before returning.
- **`DropZone.svelte`**: `batchRotations` is a flat array; each EP5 result is flattened on insert via spread + same-`taxDate` filter, so re-importing an EP5 supersedes the previous one.
- **`rotations.js / mergeRots`**: single contract — takes a flat array, sorts, reduces. The dual generator iterators (`monthsRotsIterator`, `arrayRotsIterator`) and `months14`-based bucketing are gone. `mergeable(rot, next)` extracted as a named predicate; `sortRots(rots)` extracted with its own unit tests; the two-iterator offset pattern is replaced by a forward-pass reduce that looks backward at the just-emitted entry.
- **`MonthStatus.svelte`**:
  - Renamed `nameLabel` → `header`; `dat` → `register`; `m`/`n`/`p` → `month`/`nextMonth`/`prevMonth` for semantics
  - The 14-iteration imperative loop is replaced by a single `slots.map(...)` over an explicitly-built slot list
  - `nameLabel` mutation side-effect inside `computeRequestedMonths` is gone; computed via its own `$:` block now
  - Optional chaining replaces three-clause boundary guards
  - `($tzConverter, computeRequestedMonths(data))` comma-operator pattern declares `$tzConverter` as a tracked dep, closing a pre-existing reactivity gap (base changes now refresh the empty-store tile heuristic without requiring a data change)
- **`tzOffset` extracted** to `src/utilities/dates.js` with 4 tests covering Paris, PTP, custom converter, and the no-converter fallback.

### Symmetry achieved

```js
// stores.js
const register = (type) => ({
    type,
    items: [],
    isEmpty() { return this.items.length === 0; },
});

export const rotations = resettable(register("rotations"));
export const paySlips  = resettable(register("pay"));
```

Both stores spread through the same factory. `MonthStatus`, `DropZone`, and the test-construction helpers all see the same shape now.

## Tests

- **Up from 119 → 145** passing
- 5 new for `loadedMonths` getter + edge cases
- 6 new for `sortRots` (chronological, tie-break, immutability, empty input, multi-month order)
- 4 new for `tzOffset` (Paris/PTP/custom/fallback)
- AF EP5 fixtures updated with `taxDate` on each rotation
- 17 `mergeRots` test sites updated to pass a flat array via `.flat()`

## Test plan

- [x] `npm test` — 145 passing
- [x] `npm run build` — clean
- [x] Interactive: load AF payslips and EP5s for the year, comparatif renders correctly
- [x] Interactive: re-drop same files — silent overwrite (rotations) / orange console warning (payslips)
- [x] Interactive: change base on empty store — tile heuristic re-renders (the `$tzConverter` reactivity fix)
- [x] Interactive: Dec→Jan straddler — appears as one merged rotation in the comparatif
- [x] PR Checks workflow runs

## Out of scope, surfaced for future PRs

- `addIndemnity` could be per-rotation (touches ~50 test sites + setup mutation untangling) — separate PR

## Deferred from the original roadmap

- **PR 2** (Bulletin Complémentaire support) — held by request; will revisit after v2.0
- **PR 4** — per-bulletin row rendering in `PayTable.svelte`, the visible UI delta. Builds directly on this PR's data model.