### PR TITLE
Add `Compagnie` column to `MissionActivities` table

### DIFF
--- a/src/components/MissionActivities.svelte
+++ b/src/components/MissionActivities.svelte
@@ -12,16 +12,17 @@
     <DownloadTablePDF tableIds={[tableId, tableIndemnitiesId]} filename={`fraisdemission${$taxYear}.pdf`}/>
     <table id="{tableId}" class="data">
         <thead>
-            <tr><th colspan="5">Frais de Mission {$taxYear} : <strong>{$fraisDeMission} €</strong></th></tr>
+            <tr><th colspan="6">Frais de Mission {$taxYear} : <strong>{$fraisDeMission} €</strong></th></tr>
             {#if $taxYear !== $taxData.year}
-                <tr class="warning"><th colspan="5">Attention les montants sont basés sur les données fiscales de {$taxData.year}</th></tr>
+                <tr class="warning"><th colspan="6">Attention les montants sont basés sur les données fiscales de {$taxData.year}</th></tr>
             {/if}
-            <tr><th>Date</th><th>Type</th><th>Description</th><th>Formule</th><th>Montant</th></tr>
+            <tr><th>Date</th><th>Compagnie</th><th>Type</th><th>Description</th><th>Formule</th><th>Montant</th></tr>
         </thead>
         <tbody>
             {#each $pairings as rot}
                 <tr>
                     <td>{rot.start.substring(8,10)}/{rot.start.substring(5,7)}</td>
+                    <td class="airline">{#if rot.airline}<span class="airline-tag">{rot.airline}</span>{/if}</td>
                     <td>{rot.days.toString().padStart(2, ' ')} ON</td>
                     <td>{rot.summary}</td>
                     <!-- Do not change markup below without editing DownloadTablePDF.svelte -->
@@ -32,7 +33,7 @@
         </tbody>
         <tfoot>
             {#if $pairings.reduce((a,c) => a | c.formula.includes(REFNOTE1), false)}
-                <tr><td colspan="5">1. formule tronquée pour respecter l'année fiscale</td></tr>
+                <tr><td colspan="6">1. formule tronquée pour respecter l'année fiscale</td></tr>
             {/if}
         </tfoot>
     </table>
@@ -49,9 +50,22 @@
 
 <style>
 
-td:nth-child(5), th:nth-child(5){
+td:last-child, th:last-child {
     text-align: right;
     white-space: nowrap;
+}
+td.airline {
+    text-align: center;
+    width: 1%;
+    white-space: nowrap;
+}
+.airline-tag {
+    display: inline-block;
+    padding: 1px 6px;
+    border-radius: 3px;
+    background-color: rgba(0, 0, 0, 0.06);
+    font-family: monospace;
+    font-size: 0.9em;
 }
 details[open] summary{
     margin-bottom: 2px;


### PR DESCRIPTION
## Summary

Each rotation already carries an `airline` field (set by `buildRots` and preserved through `mergeRots`), but the rotations table never surfaced it. Adds a new **Compagnie** column with an `AF` / `TO` / etc badge per row, matching the airline badge styling introduced in #52. Useful for users with mixed AF/TO/etc years to see which airline each rotation belongs to.

## Changes

- New `<th>Compagnie</th>` between *Date* and *Type*, with a per-row badge cell. Falls back to empty if `rot.airline` is missing.
- Bumped `colspan` to 6 on the title, warning, and `<tfoot>` footnote rows.
- Replaced the `td:nth-child(5)` right-align/nowrap rule for *Montant* with `td:last-child`, so it stays correct as columns shift.
- Added local `.airline-tag` and `td.airline` styles (small inline-block badge, centered, tight column).
- `DownloadTablePDF` is column-count-agnostic (it queries by `summary` and `td[title]`), so no PDF-side changes needed.

## Test plan

- [x] Load a year with AF-only rotations: confirm an `AF` badge in every row.
- [x] Confirm *Montant* column stays right-aligned with the column shift.
- [x] Open `DownloadTablePDF` and confirm the new column appears in the generated PDF.