### PR TITLE
Sum cumul per airline for cross-carrier YTD imposable

### DIFF
--- a/src/components/PayTable.svelte
+++ b/src/components/PayTable.svelte
@@ -27,21 +27,42 @@
             .reduce((acc, d) => acc + decimal2cents(d), 0);
 
     /**
-     * The YTD cumul reported across `bulletins`, as a decimal string.
+     * The YTD cumul across `bulletins`, as a decimal string.
+     *
+     * Each payslip's `cumul` field reports its own airline's YTD only,
+     * so in the case of payslips from different airlines — which carry
+     * separate YTD totals — the correct year-end figure is the **sum of
+     * each airline's largest reported cumul**.
+     *
+     * Returns undefined when no bulletin reports a usable cumul.
      *
      * @example
-     *   cumulOf([{cumul: '56644.85'}, {cumul: '0'}])  // → "56644.85"
-     *   cumulOf([{cumul: '0'}])                        // → undefined
-     *   cumulOf([])                                    // → undefined
+     *   // Single airline, full year:  max(cumul) = December cumul
+     *   cumulOf([
+     *     {airline: 'AF', cumul: '40000.00'},  // earlier month
+     *     {airline: 'AF', cumul: '56644.85'},  // December
+     *   ])  // → "56644.85"
      *
-     * @param {Array<{cumul: string}>} bulletins
+     *   // Multiple airlines: each airline's largest cumul, summed
+     *   cumulOf([
+     *     {airline: 'TO', cumul: '12000.00'},  // TO's last cumul (e.g. May)
+     *     {airline: 'AF', cumul: '44000.00'},  // AF's last cumul (e.g. December)
+     *   ])  // → "56000.00"
+     *
+     *   cumulOf([{airline: 'AF', cumul: '0'}])  // → undefined
+     *   cumulOf([])                              // → undefined
+     *
+     * @param {Array<{airline: string, cumul: string}>} bulletins
      * @returns {string | undefined}
      */
     const cumulOf = (bulletins) => {
-        const cents = Math.max(
-            0,
-            ...bulletins.map(b => decimal2cents(b.cumul)),
-        );
+        const maxByAirline = {};
+
+        for (const b of bulletins) {
+            maxByAirline[b.airline] = Math.max(maxByAirline[b.airline] ?? 0, decimal2cents(b.cumul));
+        }
+
+        const cents = Object.values(maxByAirline).reduce((sum, c) => sum + c, 0);
 
         return cents > 0
             ? cents2decimal(cents)
@@ -85,8 +106,10 @@
     $: byMonth = groupByMonth(data.items);
     $: totalFrais = cents2decimal(sumOver(data.items, b => [...b.repas, ...b.transport]));
     $: totalImposable = cents2decimal(sumOver(data.items, b => [b.imposable]));
-    $: cumulImposable12 = cumulOf(byMonth["12"] ?? []);
-    $: abbattement = ($taxData && $taxData.maxForfait10) ? Math.min((cumulImposable12||totalImposable)*0.1, $taxData.maxForfait10) : 0;
+    // Prefer the bulletin-reported cumul over summing imposable amounts;
+    // fall back to totalImposable when no cumul is loaded.
+    $: cumulImposable = cumulOf(data.items);
+    $: abbattement = ($taxData && $taxData.maxForfait10) ? Math.min((cumulImposable||totalImposable)*0.1, $taxData.maxForfait10) : 0;
     $: totalDecouchersFPRO = cents2decimal(sumOver(data.items, b => b.decouchers_fpro));
     $: estimateRatio = ( parseInt($taxYear, 10)  >= 2021) ? 2.7 : 3.31;
     $: nightsCostEstimate = (Math.ceil(parseFloat(totalDecouchersFPRO) * estimateRatio/100) * 100).toFixed(0);


### PR DESCRIPTION
## Summary

This PR fixes the year-to-date `imposable` used by the `abattement` so it stays correct for users who change carriers (e.g. AF↔TO) within the same tax year. Previously, `max(cumul across bulletins)` picked the larger of one carrier's December cumul and ignored months from the other entirely.

`cumulOf` now groups bulletins by airline, takes the largest cumul per airline, and sums them. For single-airline users the result is unchanged (max over one airline's bulletins equals that airline's December `cumul`). For multi-airline users it now reflects the combined YTD across carriers.

The call site also changes from `cumulOf(byMonth["12"] ?? [])` to `cumulOf(data.items)` — passing all bulletins lets `cumulOf` find each airline's latest cumul regardless of which month it lives in, since a transitioning user might not have a December bulletin from one of the two carriers. The variable is renamed `cumulImposable12` → `cumulImposable` to drop the now-misleading `12` suffix.

## Why

Each payslip's `cumul` field is per-airline. The abattement formula needs the **total** YTD imposable across all sources, which for a transitioning pilot is the sum of each carrier's reported YTD. Taking max gave whichever single carrier had the larger cumul.

This was identified as a remaining gap in our cross-airline preparedness during the v2.0 wrap-up. Per the discussion in #45 with the owner: [*"je te propose qu'on fasse une somme des cumuls du dernier mois présent de compagnie"*](https://github.com/flyingeek/flytax/issues/45#issuecomment-4359888461).

## Behavior matrix

| Scenario | Before | After |
|---|---|---|
| Pure AF, full year | December AF cumul ✓ | December AF cumul ✓ (unchanged) |
| Pure AF, partial year (e.g. Jan–Sep loaded) | fell back to `totalImposable` (sum of imposable) | uses largest AF cumul loaded (e.g. September's), so unchanged assuming totals match |
| AF→TO transition with December TO bulletin | TO December cumul (TO YTD only) ✗ | sum(AF's largest cumul, TO December cumul) ✓ |
| AF→TO transition with no December from either carrier | fell back to `totalImposable` ✗ | sum of each airline's largest reported cumul ✓ |

The partial-year shift (row 2) is a subtle improvement: the cumul reported on the bulletin is more authoritative than summing individual imposable amounts. Both should match in consistent data.

## What changed

- `cumulOf(bulletins)` algorithm: from `max(allCumuls)` to `sum(maxPerAirline)`
- `cumulOf` JSDoc updated with explicit examples for both single-airline and multi-airline cases
- Call site: `byMonth["12"] ?? []` → `data.items`
- Variable: `cumulImposable12` → `cumulImposable`
- One-line comment above the reactive declaration to preserve the domain rationale (bulletin cumul preferred over summed imposable)

## What didn't change

- Per-row cumul column in `PayTable` — that displays each bulletin's own cumul, unaffected
- Totals row, single-airline behaviour, formula for `abbattement`
- No new dependencies, no new files, no test fixture changes

## Test plan

- [x] `npm test` — 145 passing
- [x] `npm run build` — clean
- [x] Interactive: load a full year of AF payslips, comparatif `Abattement` value matches what it was on `main`
- [x] Interactive: synthetic AF↔TO transition data, abattement now reflects combined YTD
- [x] PR Checks workflow runs

## Out of scope

- Train station codes (`GPM`, `GPL`, …) in `iata2country` — separate concern, deferred to the Transavia v2.1 work
- UI airline distinction — already shipped in #52 and #53