### PR TITLE
refactor(parsers): move addIndemnities to a router decoration step

### DIFF
--- a/src/parsers/airfrance/ep5Parser.js
+++ b/src/parsers/airfrance/ep5Parser.js
@@ -1,4 +1,4 @@
-import { addIndemnities, buildRots } from '../../rotations';
+import { buildRots } from '../../rotations';
 import { decimalHours2iso } from '../../utilities/dates';
 import { iata2country } from '../../utilities/iata';
 import { isInTaxYearWindow, stampForTaxYear } from '../../utilities/taxYear';
@@ -87,7 +87,7 @@ const parseEP5Modern = (text, ctx) => {
         });
     }
 
-    result.rots = buildAFRotations(flights, ctx, result.date);
+    result.rots = buildAFRotations(flights, ctx);
 
     return result;
 };
@@ -137,7 +137,7 @@ const parseEP5Legacy = (text, ctx) => {
         });
     }
 
-    result.rots = buildAFRotations(flights, ctx, result.date);
+    result.rots = buildAFRotations(flights, ctx);
 
     return result;
 };
@@ -154,20 +154,15 @@ const sortFlights = (flights) => flights.sort((a, b) => {
     return c === 0 ? a.end.localeCompare(b.end) : c;
 });
 
-const buildAFRotations = (flights, ctx, taxDate) => {
-    const rots = buildRots(
-        sortFlights(flights),
-        {
-            tzConverter: ctx.tzConverter,
-            base: ctx.base,
-            iataMap: iata2country,
-            airline: 'AF',
-        },
-    );
-
-    return addIndemnities(ctx.taxYear, rots, ctx.taxData, ctx.tzConverter, ctx.fileName)
-        .map((rot) => ({...rot, taxDate}));
-};
+const buildAFRotations = (flights, ctx) => buildRots(
+    sortFlights(flights),
+    {
+        tzConverter: ctx.tzConverter,
+        base: ctx.base,
+        iataMap: iata2country,
+        airline: 'AF',
+    },
+);
 
 /**
  * Locate the month/year header in an EP5 document.

--- a/src/parsers/router.js
+++ b/src/parsers/router.js
@@ -1,6 +1,16 @@
+import { addIndemnities } from '../rotations';
 import { airfranceDetectors } from './airfrance';
 
 const detectors = [...airfranceDetectors];
+
+const decorate = (ctx) => (envelope) => {
+    if (envelope.type !== 'rotations' || !envelope.rots) return envelope;
+    return {
+        ...envelope,
+        rots: addIndemnities(ctx.taxYear, envelope.rots, ctx.taxData, ctx.tzConverter, ctx.fileName)
+            .map((rot) => ({...rot, taxDate: envelope.date})),
+    };
+};
 
 /**
  * Dispatch a piece of extracted PDF text to the first matching parser.
@@ -26,7 +36,7 @@ export const router = (text, fileName, fileOrder, taxYear, taxData, base, tzConv
     const ctx = { fileName, fileOrder, taxYear, taxData, base, tzConverter };
 
     for (const { match, parse } of detectors) {
-        if (match(text, ctx)) return parse(text, ctx);
+        if (match(text, ctx)) return parse(text, ctx).map(decorate(ctx));
     }
 
     return [{


### PR DESCRIPTION
## Summary

Parsers were coupling two distinct concerns: turning PDF text into rotations (raw flights, nights, structure) and computing tax-year indemnities (countries, formula, indemnity amount). This PR pulls `addIndemnities` and the `taxDate` stamp out of the EP5 parser and runs them once at the router boundary via a small `decorate(ctx)` helper.

## Why

- Parsers needed `taxData` loaded just to fill envelope fields they don't otherwise care about.
- Changing `taxYear` forced a re-parse of the PDF, even though the rotations themselves don't depend on it.
- Every new airline parser (Transavia PV is next) would have duplicated the same 3-line `addIndemnities + taxDate.map` boilerplate.

After this change:
- `src/parsers/airfrance/ep5Parser.js` no longer imports `addIndemnities`; `buildAFRotations` collapses to a straight `buildRots` call.
- `src/parsers/router.js` maps `decorate(ctx)` over each parser result, applying indemnities and stamping `taxDate = envelope.date` onto every rotation.
- The Transavia PV parser branch will rebase on top and get the same decoration for free.

## Why not fold `taxDate` into `addIndemnities`?

Kept them separate on purpose:
- `addIndemnities` takes `taxYear` (a 4-digit string); `taxDate` is `envelope.date` (a parser-produced month stamp like `"2025-04"`). Different inputs.
- `addIndemnities` computes per-rotation tax fields; `taxDate` is a denormalized backref to the envelope's month bucket. Different concerns.
- `addIndemnities` has ~8 test callers and one internal caller in `src/rotations.js`; none have or want a `taxDate`. Threading it through would add a param those callers don't need.

## Test plan

- [x] `npm test`
- [x] Parser modules no longer import `addIndemnities`
- [x] `taxDate` on every rotation still equals `envelope.date`
- [x] Envelope shape unchanged (existing AF parser tests go through `router()` and pass without edits)