### PR TITLE
Split AF payslip transport into ikv + transit (captures Navigo)

### DIFF
--- a/src/components/PayTable.svelte
+++ b/src/components/PayTable.svelte
@@ -14,9 +14,10 @@
      * Sum decimal-string fields across a list of bulletins, in cents.
      *
      * @example
-     *   sumOver(items, b => [b.imposable])                 // total imposable in cents
-     *   sumOver(items, b => [...b.repas, ...b.transport])  // frais d'emploi in cents
-     *   sumOver(items, b => b.decouchers_fpro)             // découchers in cents
+     *   sumOver(items, b => [b.imposable])             // total imposable in cents
+     *   sumOver(items, b => [...b.repas, ...b.ikv])    // frais d'emploi in cents
+     *   sumOver(items, b => b.transit)                 // public-transit in cents
+     *   sumOver(items, b => b.decouchers_fpro)         // découchers in cents
      *
      * @param {Array<object>} bulletins
      * @param {(bulletin: object) => Array<string>} getValues
@@ -104,7 +105,9 @@
     }
 
     $: byMonth = groupByMonth(data.items);
-    $: totalFrais = cents2decimal(sumOver(data.items, b => [...b.repas, ...b.transport]));
+    $: totalFrais = cents2decimal(sumOver(data.items, b => [...b.repas, ...b.ikv]));
+    $: totalTransit = cents2decimal(sumOver(data.items, b => b.transit));
+    $: hasTransit = decimal2cents(totalTransit) > 0;
     $: totalImposable = cents2decimal(sumOver(data.items, b => [b.imposable]));
     // Prefer the bulletin-reported cumul over summing imposable amounts;
     // fall back to totalImposable when no cumul is loaded.
@@ -163,6 +166,11 @@
     <tr>
         <td colspan="3">{roadTripInformation}</td>
     </tr>
+    {#if hasTransit}
+    <tr>
+        <td colspan="3">Vos bulletins indiquent <b>{localeCurrency(totalTransit)}</b> de remboursements de transports en commun (Navigo / train), non inclus dans le calcul ci-dessus. Si vous incluez le coût de votre abonnement dans votre déclaration aux frais réels, n’oubliez pas d’en soustraire ce montant.</td>
+    </tr>
+    {/if}
 </tfoot>
 </table>
 {:else}
@@ -171,7 +179,7 @@
 <table class="data" id={tableId}>
     <thead>
         <tr><th colspan="6">Détails des salaires {$taxYear}</th></tr>
-        <tr><th>Mois</th><th>Compagnie</th><th>Montant imposable</th><th>Cumul imposable</th><th>Frais d’emploi ¹</th><th>Découchers F PRO ²</th></tr>
+        <tr><th>Mois</th><th>Compagnie</th><th>Montant imposable</th><th>Cumul imposable</th><th>Frais d’emploi ¹{#if hasTransit}&nbsp;³{/if}</th><th>Découchers F PRO ²</th></tr>
     </thead>
     <tbody>
         {#each months as month, i}
@@ -185,7 +193,7 @@
                     <td class="airline">{#if b}<span class="airline-tag">{b.airline}</span>{/if}</td>
                     <td>{b ? localeCurrency(b.imposable) : ""}</td>
                     <td>{b && decimal2cents(b.cumul) > 0 ? localeCurrency(b.cumul) : ""}</td>
-                    <td>{b ? localeCurrency(cents2decimal(sumOver([b], x => [...x.repas, ...x.transport]))) : ""}</td>
+                    <td>{b ? localeCurrency(cents2decimal(sumOver([b], x => [...x.repas, ...x.ikv]))) : ""}</td>
                     <td>{b ? localeCurrency(cents2decimal(sumOver([b], x => x.decouchers_fpro))) : ""}</td>
                 </tr>
             {/each}
@@ -200,11 +208,16 @@
             <th>{localeCurrency(totalDecouchersFPRO)}</th>
         </tr>
         <tr>
-            <td colspan="6">1. Les Frais d’emploi comprennent les lignes IND.REPAS, INDEMNITE REPAS, IR.FIN ANNEE DOUBL, IND. TRANSPORT, IND. TRANSPORT EXO, FRAIS REELS TRANSP, R. FRAIS DE TRANSPORT, IR EXONEREES, IR NON EXONEREES du bulletin de paye.</td>
+            <td colspan="6">1. Les Frais d’emploi comprennent les lignes IND.REPAS, INDEMNITE REPAS, IR.FIN ANNEE DOUBL, IND. TRANSPORT, IND. TRANSPORT EXO, IR EXONEREES, IR NON EXONEREES du bulletin de paye.</td>
         </tr>
         <tr>
             <td colspan="6">2. Cette colonne reprend la ligne I.DECOUCHERS F.PRO, elle est utilisée pour l’estimation. Pour les impôts, c’est uniquement l’attestation des nuitées AF qui doit être prise en compte.</td>
         </tr>
+        {#if hasTransit}
+        <tr>
+            <td colspan="6">3. Vos bulletins indiquent <b>{localeCurrency(totalTransit)}</b> de remboursements de transports en commun (Navigo / train). Ces montants ne sont pas inclus dans les Frais d’emploi ci-dessus. Si vous incluez le coût de votre abonnement dans votre déclaration aux frais réels, n’oubliez pas d’en soustraire ce montant.</td>
+        </tr>
+        {/if}
     </tfoot>
 </table>
 {:else}

--- a/src/parsers/airfrance/payParser.js
+++ b/src/parsers/airfrance/payParser.js
@@ -90,7 +90,8 @@ export const payParser = (text, ctx) => {
     }
 
     result.repas = matchAll(text, REPAS_RE, "0").map(decimal);
-    result.transport = matchAll(text, TRANSPORT_RE, "0").map(decimal);
+    result.ikv = matchAll(text, IKV_RE, "0").map(decimal);
+    result.transit = matchAll(text, TRANSIT_RE, "0").map(decimal);
     result.decouchers_fpro = matchAll(text, DECOUCHERS_FPRO_RE, "0").map(decimal);
 
     // Surface each soft failure as its own envelope so DropZone can log it.
@@ -112,5 +113,6 @@ const NET_RE = /_Mensuel_[\-0-9, ]+_{1,2}([\-0-9, ]+)_/g;
 const CUMUL_RE = /_Annuel_[\-0-9, ]+_{1,2}([\-0-9, ]+)_/g;
 const REPAS_RE = /(?:IND\.REPAS_+|INDEMNITE REPAS_+|IR\.FIN ANNEE DOUBL_+|IR EXONEREES_+|IR NON EXONEREES_+)([\-0-9, ]+)/g;
 // Allows for optional quantity and rate before amount
-const TRANSPORT_RE = /(?:IND\. TRANSPORT EXO_+|IND\. TRANSPORT_+|FRAIS REELS TRANSP_+|R\. FRAIS DE TRANSPORT_+)(?:[\-0-9, ]+_[\-0-9, ]+_)?([\-0-9, ]+)/g;
+const IKV_RE = /(?:IND\. TRANSPORT EXO_+|IND\. TRANSPORT_+)(?:[\-0-9, ]+_[\-0-9, ]+_)?([\-0-9, ]+)/g;
+const TRANSIT_RE = /(?:FRAIS REELS TRANSP_+|R\. FRAIS DE TRANSPORT_+|REMB\.CARTE NAVIGO_+)(?:[\-0-9, ]+_[\-0-9, ]+_)?([\-0-9, ]+)/g;
 const DECOUCHERS_FPRO_RE = /(?:_I.DECOUCHERS F.PRO_+)([\-0-9, ]+)/g;

--- a/test/parsers/airfrance.test.js
+++ b/test/parsers/airfrance.test.js
@@ -24,7 +24,8 @@ test('AF payslip parsing', () => {
         imposable: '8811.55',
         cumul: '56644.85',
         repas: ['526.36'],
-        transport: ['0.00'],
+        ikv: ['0.00'],
+        transit: ['20.35', '61.05'],
         decouchers_fpro: ['253.20'],
     }]);
 });


### PR DESCRIPTION
## Summary

This PR refactors `result.transport` on the AF payslip parser into two fields — `ikv` and `transit` — and adds capture of the previously-ignored `REMB.CARTE NAVIGO` line. It also updated PayTable to compute "Frais d'emploi" as `repas + ikv` (no longer including transit) and to surface transit reimbursements as conditional informational text.

This PR seeks to resolve #61.
The TO parser in #62 will follow to align on the same envelope shape and ship the same UI behaviour.

## Rationale

`IND. TRANSPORT` family lines (IKV — employer kilometric indemnity for personal vehicle use) and `REMB.CARTE NAVIGO` / `FRAIS REELS TRANSP` / `R. FRAIS DE TRANSPORT` (transit — partial refund of employee-paid public-transport costs) are semantically different and treated differently for tax purposes.

IKV always belongs in the "frais d'emploi" deduction baseline; transit only matters if the pilot declared their Navigo / train cost as a real expense. Lumping them obscured the distinction and silently zeroed-out Navigo amounts on every AF bulletin.

## Test plan

- [x] `npm test` — 146/146 green; existing AF payslip test updated to pin the two Navigo lines (`20.35` + `61.05`) the parser now captures.
- [x] Manual smoke (`npm run dev`):
  - AF payslip with Navigo → Comparatif and data table both show the new conditional notes; "Frais d'emploi" total drops by the Navigo amount vs. before (since transit no longer counts).
  - AF payslip without Navigo → no UI change.
  - EP4/EP5/Nuitées → no regression.