### PR TITLE
Refresh PayTable UI and Help.md for multi-airline support

### DIFF
--- a/src/components/DownloadTablePDF.svelte
+++ b/src/components/DownloadTablePDF.svelte
@@ -82,6 +82,32 @@
                     e.parentNode.parentNode.innerText = e.innerText;
                 });
             }
+            // PayTable footnotes use <ol> + <details> reveals. autoTable
+            // flattens both: list-item numbering and line breaks are
+            // lost, and `includeHiddenHtml: true` includes the details
+            // body anyway. Replace the <ol> with a flat <div> of
+            // numbered <p>s (details stripped) during PDF generation
+            // and restore the original afterwards.
+            const paytableOlBackups = [];
+            if (tableIds.includes('PayTable')) {
+                const table = document.getElementById('PayTable');
+                table.querySelectorAll('ol.footnotes').forEach(ol => {
+                    const placeholder = document.createComment('paytable-ol');
+                    ol.parentNode.insertBefore(placeholder, ol);
+                    // autoTable flattens block-level elements (<p>, <li>)
+                    // when extracting cell text, so use explicit <br><br>
+                    // separators between items — those it respects.
+                    const flatHTML = [...ol.children].map((li, i) => {
+                        const clone = li.cloneNode(true);
+                        clone.querySelectorAll('details').forEach(d => d.remove());
+                        return `${i + 1}. ${clone.innerHTML.trim()}`;
+                    }).join('<br><br>');
+                    const flat = document.createElement('div');
+                    flat.innerHTML = flatHTML;
+                    ol.parentNode.replaceChild(flat, ol);
+                    paytableOlBackups.push({original: ol, flat, placeholder});
+                });
+            }
             for (const tableId of tableIds) {
                 const table = document.getElementById(tableId);
                 table.classList.add("print");
@@ -110,6 +136,10 @@
                     e.innerHTML = `<details><summary>${e.innerText}</summary>${e.title}</details>`;
                 });
             }
+            paytableOlBackups.forEach(({original, flat, placeholder}) => {
+                flat.parentNode.replaceChild(original, flat);
+                placeholder.parentNode.removeChild(placeholder);
+            });
             for (const tableId of tableIds) {
                 const table = document.getElementById(tableId);
                 table.classList.remove("print");

--- a/src/components/PayTable.svelte
+++ b/src/components/PayTable.svelte
@@ -108,16 +108,26 @@
     $: totalFrais = cents2decimal(sumOver(data.items, b => [...b.repas, ...b.ikv]));
     $: totalTransit = cents2decimal(sumOver(data.items, b => b.transit));
     $: hasTransit = decimal2cents(totalTransit) > 0;
+    $: hasAFPayslips = data.items.some(b => b.airline === 'AF');
+    $: hasTOPayslips = data.items.some(b => b.airline === 'TO');
     $: totalImposable = cents2decimal(sumOver(data.items, b => [b.imposable]));
     // Prefer the bulletin-reported cumul over summing imposable amounts;
     // fall back to totalImposable when no cumul is loaded.
     $: cumulImposable = cumulOf(data.items);
+    $: lastBulletinByAirline = data.items.reduce((acc, b) => {
+        if (!acc[b.airline] || b.paymentDate > acc[b.airline].paymentDate) acc[b.airline] = b;
+        return acc;
+    }, {});
     $: abbattement = ($taxData && $taxData.maxForfait10) ? Math.min((cumulImposable||totalImposable)*0.1, $taxData.maxForfait10) : 0;
     $: totalDecouchersFPRO = cents2decimal(sumOver(data.items, b => b.decouchers_fpro));
     $: estimateRatio = ( parseInt($taxYear, 10)  >= 2021) ? 2.7 : 3.31;
     $: nightsCostEstimate = (Math.ceil(parseFloat(totalDecouchersFPRO) * estimateRatio/100) * 100).toFixed(0);
     $: updateFraisHebergementInput($fraisHebergement, nightsCostEstimate);
-    $: fraisReels = parseFloat($fraisDeMission) - parseFloat($fraisHebergement || $fraisHebergementInput || nightsCostEstimate) - parseFloat(totalFrais);
+    // User input wins so a pilot with mixed AF + TO can edit the
+    // attestation-loaded value to add their TO hotel costs on top.
+    // `$fraisHebergement` (AF attestation total) becomes informational
+    // and only feeds the math as a fallback when the input is empty.
+    $: fraisReels = parseFloat($fraisDeMission) - parseFloat($fraisHebergementInput || $fraisHebergement || nightsCostEstimate) - parseFloat(totalFrais);
     $: roadTripInformation = roadTrips($pairings, $taxYear);
 
 </script>
@@ -132,15 +142,17 @@
     <tr>
         <th colspan="3">
             Comparatif {$taxYear}
-            {#if (!$fraisHebergementInput || $fraisHebergementInput == nightsCostEstimate)}
-                <div class="estimate" transition:fade|local><small>basé sur une estimation des nuitées à ±20%</small></div>
+            {#if $fraisHebergement}
+                <div class="estimate" transition:fade|local><small>L’attestation Air&nbsp;France indique {localeCurrency($fraisHebergement, 0)}</small></div>
+            {:else if hasAFPayslips && (!$fraisHebergementInput || $fraisHebergementInput == nightsCostEstimate)}
+                <div class="estimate" transition:fade|local><small>basé sur une estimation des nuitées AF à ±20%</small></div>
             {/if}
         </th>
     </tr>
     <tr>
-        <th>Nuitées AF</th>
-        <th>Frais&nbsp;de&nbsp;Mission -&nbsp;Nuitées -&nbsp;Frais&nbsp;d’emploi</th>
-        <th>Abattement de 10% plafonné</th>
+        <th>Frais d’hébergement</th>
+        <th>Frais&nbsp;de&nbsp;Mission -&nbsp;Frais&nbsp;d’hébergement -&nbsp;Frais&nbsp;d’emploi</th>
+        <th>Abattement de 10&#8239;% plafonné</th>
     </tr>
     {#if $taxYear !== $taxData.year}
     <tr class="warning"><th colspan="3">Attention les montants sont basés sur les données fiscales de {$taxData.year}</th></tr>
@@ -149,20 +161,25 @@
 <tbody>
     <tr>
         <td>
-            <input name="nuitees" type="number" disabled={!!$fraisHebergement} bind:value="{$fraisHebergementInput}" min="0" step="100" placeholder="{($fraisHebergement) ? $fraisHebergement : nightsCostEstimate}"/>
+            <input name="nuitees" type="number" bind:value="{$fraisHebergementInput}" min="0" step="100" placeholder="{$fraisHebergement || nightsCostEstimate}"/>
         </td>
-        <td>{$fraisDeMission} - {parseFloat($fraisHebergement || $fraisHebergementInput || nightsCostEstimate).toFixed(0)} - {parseFloat(totalFrais).toFixed(0)} = {fraisReels.toFixed(0)} €</td>
-        <td>{abbattement.toFixed(0)} €</td>
+        <td>{$fraisDeMission} - {parseFloat($fraisHebergementInput || $fraisHebergement || nightsCostEstimate).toFixed(0)} - {parseFloat(totalFrais).toFixed(0)} = {fraisReels.toFixed(0)}&#8239;€</td>
+        <td>{abbattement.toFixed(0)}&#8239;€</td>
     </tr>
 </tbody>
 <tfoot>
     <tr>
         {#if (fraisReels >= abbattement)}
-        <td colspan="3">Sans tenir compte de vos autres frais, vous serez déjà gagnant de <b>{(fraisReels - abbattement).toFixed(0)} €</b> en passant aux frais réels.</td>
+        <td colspan="3">Sans tenir compte de vos autres frais, vous serez déjà gagnant de <b>{(fraisReels - abbattement).toFixed(0)}&#8239;€</b> en passant aux frais réels.</td>
         {:else}
-        <td colspan="3">Il faudra que vos autres frais atteignent <b>{(abbattement - fraisReels).toFixed(0)} €</b> pour qu'une déclaration aux frais réels soit plus avantageuse.</td>
+        <td colspan="3">Il faudra que vos autres frais atteignent <b>{(abbattement - fraisReels).toFixed(0)}&#8239;€</b> pour qu'une déclaration aux frais réels soit plus avantageuse.</td>
         {/if}
     </tr>
+    {#if hasTOPayslips}
+    <tr>
+        <td colspan="3">⚠️ Pensez à ajouter vos <b>frais d’hébergement Transavia</b> au champ ci-dessus&#8239;: ils ne sont pas calculés automatiquement (cf. l’aide pour le détail du calcul).</td>
+    </tr>
+    {/if}
     <tr>
         <td colspan="3">{roadTripInformation}</td>
     </tr>
@@ -174,12 +191,12 @@
 </tfoot>
 </table>
 {:else}
-<p>Merci de charger vos EP4/EP5 pour afficher le comparatif</p>
+<p>Merci de charger vos relevés d’activité (AF&#8239;: EP5 / TO&#8239;: Relevé d’activité rémunérée PV) pour afficher le comparatif</p>
 {/if}
 <table class="data" id={tableId}>
     <thead>
-        <tr><th colspan="6">Détails des salaires {$taxYear}</th></tr>
-        <tr><th>Mois</th><th>Compagnie</th><th>Montant imposable</th><th>Cumul imposable</th><th>Frais d’emploi ¹{#if hasTransit}&nbsp;³{/if}</th><th>Découchers F PRO ²</th></tr>
+        <tr><th colspan="5">Détails des salaires {$taxYear}</th></tr>
+        <tr><th>Mois</th><th>Compagnie</th><th>Montant imposable</th><th>Cumul imposable</th><th>Frais d’emploi ¹{#if hasTransit}&nbsp;²{/if}</th></tr>
     </thead>
     <tbody>
         {#each months as month, i}
@@ -192,9 +209,8 @@
                     {/if}
                     <td class="airline">{#if b}<span class="airline-tag">{b.airline}</span>{/if}</td>
                     <td>{b ? localeCurrency(b.imposable) : ""}</td>
-                    <td>{b && decimal2cents(b.cumul) > 0 ? localeCurrency(b.cumul) : ""}</td>
+                    <td class:cumul-max={b && b === lastBulletinByAirline[b.airline] && decimal2cents(b.cumul) > 0}>{b && decimal2cents(b.cumul) > 0 ? localeCurrency(b.cumul) : ""}</td>
                     <td>{b ? localeCurrency(cents2decimal(sumOver([b], x => [...x.repas, ...x.ikv]))) : ""}</td>
-                    <td>{b ? localeCurrency(cents2decimal(sumOver([b], x => x.decouchers_fpro))) : ""}</td>
                 </tr>
             {/each}
         {/each}
@@ -205,19 +221,71 @@
             <th>{localeCurrency(totalImposable)}</th>
             <th></th>
             <th>{localeCurrency(totalFrais)}</th>
-            <th>{localeCurrency(totalDecouchersFPRO)}</th>
         </tr>
         <tr>
-            <td colspan="6">1. Les Frais d’emploi comprennent les lignes IND.REPAS, INDEMNITE REPAS, IR.FIN ANNEE DOUBL, IND. TRANSPORT, IND. TRANSPORT EXO, IR EXONEREES, IR NON EXONEREES du bulletin de paye.</td>
+            <td colspan="5">
+                <ol class="footnotes">
+                    <li>
+                        Les Frais d’emploi comprennent vos indemnités de repas et indemnités kilométriques (IKV).
+                        <details>
+                            <summary>Voir les lignes prises en compte</summary>
+                            <ul class="rubriques">
+                                <li><b>Air&nbsp;France</b>
+                                    <ul>
+                                        <li>IND.REPAS</li>
+                                        <li>INDEMNITE REPAS</li>
+                                        <li>IR.FIN ANNEE DOUBL</li>
+                                        <li>IR EXONEREES</li>
+                                        <li>IR NON EXONEREES</li>
+                                        <li>IND. TRANSPORT</li>
+                                        <li>IND. TRANSPORT EXO</li>
+                                    </ul>
+                                </li>
+                                <li><b>Transavia</b>
+                                    <ul>
+                                        <li>4169 Indemnité de nettoyage</li>
+                                        <li>4170 Indemnité de repas Etranger</li>
+                                        <li>4171 Indemnité de repas France</li>
+                                        <li>4566 Indemn. Repas Soumise</li>
+                                        <li>4566 Indemnité repas soumise</li>
+                                        <li>4567 Ind.IKV Soumis</li>
+                                        <li>21013 Indemnités IKV</li>
+                                        <li>21014 Indemnité repas</li>
+                                        <li>21020 Indemnité Transport</li>
+                                        <li>21038 Indemnité Transport Sup.</li>
+                                    </ul>
+                                </li>
+                            </ul>
+                        </details>
+                    </li>
+                    {#if hasTransit}
+                    <li>
+                        Vos bulletins indiquent <b>{localeCurrency(totalTransit)}</b> de remboursements de transports en commun (Navigo / train). Ces montants ne sont pas inclus dans les Frais d’emploi ci-dessus. Si vous incluez le coût de votre abonnement dans votre déclaration aux frais réels, n’oubliez pas d’en soustraire ce montant.
+                        <details>
+                            <summary>Voir les lignes prises en compte</summary>
+                            <ul class="rubriques">
+                                <li><b>Air&nbsp;France</b>
+                                    <ul>
+                                        <li>REMB.CARTE NAVIGO</li>
+                                        <li>FRAIS REELS TRANSP</li>
+                                        <li>R. FRAIS DE TRANSPORT</li>
+                                    </ul>
+                                </li>
+                                <li><b>Transavia</b>
+                                    <ul>
+                                        <li>4568 Remb.Transport Soumis</li>
+                                        <li>4569 Remb.Transport Soumis</li>
+                                        <li>21010 Rembt Ind Trsprt/Navigo/Velib</li>
+                                        <li>21011 Remb.Transport</li>
+                                    </ul>
+                                </li>
+                            </ul>
+                        </details>
+                    </li>
+                    {/if}
+                </ol>
+            </td>
         </tr>
-        <tr>
-            <td colspan="6">2. Cette colonne reprend la ligne I.DECOUCHERS F.PRO, elle est utilisée pour l’estimation. Pour les impôts, c’est uniquement l’attestation des nuitées AF qui doit être prise en compte.</td>
-        </tr>
-        {#if hasTransit}
-        <tr>
-            <td colspan="6">3. Vos bulletins indiquent <b>{localeCurrency(totalTransit)}</b> de remboursements de transports en commun (Navigo / train). Ces montants ne sont pas inclus dans les Frais d’emploi ci-dessus. Si vous incluez le coût de votre abonnement dans votre déclaration aux frais réels, n’oubliez pas d’en soustraire ce montant.</td>
-        </tr>
-        {/if}
     </tfoot>
 </table>
 {:else}
@@ -274,7 +342,7 @@
         font-size: initial;
     }
     .col1 {
-        width: 140px;
+        width: 180px;
     }
     .col2 {
         width: 50%;
@@ -302,7 +370,8 @@
     }
     td input {
         margin-bottom: 0;
-        width: 130px;
+        width: 100%;
+        box-sizing: border-box;
     }
     td input:disabled {
         color: var(--green);
@@ -313,10 +382,10 @@
         font-family: monospace;
         font-size: 1.3rem;
     }
-    td:nth-last-child(-n+4):not([colspan]), th:nth-last-child(-n+4):not([colspan]) {
+    td:nth-last-child(-n+3):not([colspan]), th:nth-last-child(-n+3):not([colspan]) {
         text-align: right;
     }
-    td:nth-last-child(-n+4):not([colspan]) {
+    td:nth-last-child(-n+3):not([colspan]) {
         white-space: nowrap;
     }
     tbody > tr {
@@ -338,7 +407,35 @@
         font-family: monospace;
         font-size: 0.9em;
     }
-    tbody > tr.december > td:nth-last-child(3) { /* cumul mois 12 */
+    tbody > tr > td.cumul-max { /* last cumul row, per airline */
         font-weight: bold;
+    }
+    /* Footnotes: keep numeric counter aligned with content; let text
+       wrap under the content, not under the number. */
+    ol.footnotes {
+        padding-left: 1.5em;
+        margin: 0;
+    }
+    ol.footnotes > li {
+        padding-left: 0.25em;
+    }
+    ol.footnotes > li + li {
+        margin-top: 0.5em;
+    }
+    ol.footnotes details {
+        margin-top: 0.25em;
+    }
+    ul.rubriques {
+        margin: 0.25em 0 0 0;
+        padding-left: 1.5em;
+    }
+    ul.rubriques > li {
+        margin: 0.15em 0;
+    }
+    ul.rubriques ul {
+        margin: 0.15em 0 0.4em 0;
+        padding-left: 1.25em;
+        font-family: monospace;
+        font-size: 1em;
     }
 </style>

--- a/src/pages/Help.md
+++ b/src/pages/Help.md
@@ -7,7 +7,7 @@
 ## Préambule
 
 Cette application a été conçue pour le PilotPad. Elle nécessite des navigateurs récents pour fonctionner&#8239;: Safari iOS13+/ Mac(Mojave/Catalina/Big Sur/Monterey), Firefox 86+, Chrome 87+ et Microsoft Edge 87+ sont compatibles.
-Les PDF utilisés ne transitent sur aucun serveur, tout est calculé localement dans votre navigateur. L’app ne collecte aucune donnée. Tout est __100 % SECURE__.
+Les PDF utilisés ne transitent sur aucun serveur, tout est calculé localement dans votre navigateur. L’app ne collecte aucune donnée. Tout est __100 % SECURE__.
 
 ## Objectifs
 
@@ -17,14 +17,14 @@ Calculer rapidement, facilement, et sans partage de données&#8239;:
 
 - le décompte des frais de mission, conformément à la méthodologie et aux conventions de calcul du SNPL
 - les frais d’emploi des PN qui doivent s’ajouter aux revenus
-- une estimation du montant des nuitées payées par AF
-- la différence entre (Frais de Mission - Nuitées - Frais d’emploi) et un abattement de 10 % plafonné
+- pour Air&nbsp;France, une estimation du montant des nuitées payées par l’employeur
+- la différence entre (Frais de Mission - Frais d’hébergement - Frais d’emploi) et un abattement de 10 % plafonné
 
-__{@html htmlLogo}__ fonctionne aussi pour les pilotes basés en province. (lire au préalable "Choix de la base").
+__{@html htmlLogo}__ fonctionne pour les PN Air&nbsp;France et Transavia, basés à Paris ou en province (lire au préalable "Choix de la base").
 
 ## Utilisation sur l'iPad
 
-Sur MyPeopleDoc, commencez par sélectionner les bulletins de salaire de l'année N, et les ep4-ep5 de décembre N-1 à février N+1. Puis, en cliquant sur téléchargement, vous recevrez un lien par email. Dans votre dossier de téléchargement sur l'iPad, cliquez sur l'archive téléchargée, elle va se décompresser. Ensuite, après avoir vérifié que l'année N est bien sélectionnée en haut à droite de  __{@html htmlLogo}__, deux solutions:
+Sur MyPeopleDoc, commencez par sélectionner les bulletins de salaire de l'année N, et vos relevés d’activité (EP5 pour Air&nbsp;France, Relevé d’activité rémunérée PV pour Transavia) de décembre N-1 à février N+1. Puis, en cliquant sur téléchargement, vous recevrez un lien par email. Dans votre dossier de téléchargement sur l'iPad, cliquez sur l'archive téléchargée, elle va se décompresser. Ensuite, après avoir vérifié que l'année N est bien sélectionnée en haut à droite de  __{@html htmlLogo}__, deux solutions:
 
 - Soit, vous cliquez dans la zone de la page Frais de Mission ou de la page Salaire, puis vous choisissez le dossier des fichiers décompressés, puis vous cliquez sur "Sélectionner", puis "Tout select." et enfin, "Ouvrir"
 - Soit, vous utilisez le mode Slide Over, ou le mode SplitView, avec l'application Fichiers, et vous faites glisser le dossier des fichiers décompressés dans la zone de la page Frais de Mission ou de la page Salaire
@@ -43,20 +43,27 @@ Si vous le souhaitez, l’application peut être installée sur l’écran d’a
 
 En cas d’anomalie, le pictogramme <svg style="width: 1em; display: inline-block; height: 1em; vertical-align: text-top; fill:red"><use xlink:href="#alert"/></svg> apparaîtra en haut à droite, le cliquer affichera les détails. Si un message d’erreur apparaissait dans la table des résultats, merci de me contacter.
 
-- L'alerte "absence d'EP5" est normale sur les fichiers ep4-ep5 de régularisation ou les mois sans vols (lire la rubrique "Activités sol/simulateur & QT"). Un mois sans vol reste bleu
-- L'erreur "fichier non reconnu" est normale pour un PDF ne contenant ni un bulletin de salaire, ni un EP5, ni une attestation de nuitées
+- L'alerte "absence d'EP5" (Air&nbsp;France) est normale sur les fichiers EP4-EP5 de régularisation ou les mois sans vols (lire la rubrique "Activités sol/simulateur & QT") — un mois sans vol reste bleu
+- L'erreur "fichier non reconnu" est normale pour un PDF ne contenant ni un bulletin de salaire, ni un relevé d’activité (EP5 ou Relevé d’activité rémunérée PV), ni une attestation de nuitées
 - En cas de message "Erreur: nuitées > nb de jours", si vous êtes basé en province, assurez-vous d'avoir lu la rubrique "Choix de la base"
 
 __Avertissement&#8239;:__ L’application est une aide au calcul des frais professionels sous licence GPLv3.0, les PN restents seuls responsables face à l’administration pour justifier l’exactitude de leur déclaration.
 
-## Attestation des nuitées AF
+## Frais d’hébergement
 
-Air France fournit cette attestation dans l’EP4 de février de l'année n + 1, mais un correctif est susceptible d’être diffusé jusqu’en avril dans un fichier annexe. En attendant ce document, __{@html htmlLogo}__ estime le montant ce qui permet de donner un ordre de grandeur. L’estimation utilise la colonne Découchers F PRO et elle est modifiable. Une fois votre attestation reçue, vous pouvez soit indiquer son montant directement, soit glisser l’attestation dans la zone de dépôt. Merci pour vos retours concernant la fiabilité de l’estimation.
+Le champ "Frais d’hébergement" du comparatif correspond au montant total des nuitées d’hôtel payées par l’employeur sur l’année. Il est utilisé pour le calcul des frais réels.
+
+__Air&nbsp;France__ fournit une attestation des nuitées dans l’EP4 de février de l'année N&nbsp;+&nbsp;1, mais un correctif est susceptible d’être diffusé jusqu’en avril dans un fichier annexe.\
+En attendant ce document, __{@html htmlLogo}__ estime le montant ce qui permet de donner un ordre de grandeur (basé sur la ligne I.DECOUCHERS F.PRO du bulletin de paie). L’estimation est modifiable.\
+Une fois l’attestation reçue, vous pouvez soit indiquer son montant directement, soit glisser l’attestation dans la zone de dépôt. Merci pour vos retours concernant la fiabilité de l’estimation.
+
+__Transavia__ ne fournit pas d’attestation récapitulative, mais publie un barème indiquant le coût d’une nuitée par escale et hôtel. Le total annuel se calcule donc à la main&#8239;: pour chaque escale, multipliez le coût d’une nuitée par le nombre de découchers, puis additionnez l’ensemble. Le montant obtenu doit être saisi manuellement dans le champ "Frais d’hébergement" du comparatif.\
+Le récapitulatif des découchers sur la page Frais de Mission liste vos nuitées par escale et facilite ce calcul.
 
 ## Choix de la base
 
-La base peut être modifiée chaque mois&#8239;: on choisit une base, on dépose les EP5 de cette base&#8239;;
-on change de base et l’on peut déposer les EP5 pour cette nouvelle base. En cas d’erreur, il est possible de changer de base et de recharger les EP5.
+La base peut être modifiée chaque mois&#8239;: on choisit une base, on dépose les relevés d’activité (EP5 ou PV) de cette base&#8239;;
+on change de base et l’on peut déposer les relevés pour cette nouvelle base. En cas d’erreur, il est possible de changer de base et de recharger les relevés.
 
 Le choix de la base se fait au-dessus de la zone de dépôt sur la page Frais de mission.
 

--- a/src/pages/HomePage.svelte
+++ b/src/pages/HomePage.svelte
@@ -33,7 +33,7 @@
             </svg>
 
             <ol slot="content">
-                <li>Récupérez vos EP4/EP5 et vos bulletins de salaire sur <Link href="https://www.mypeopledoc.com">MyPeopleDoc</Link></li>
+                <li>Récupérez vos relevés d’activité et vos bulletins de salaire sur <Link href="https://www.mypeopledoc.com">MyPeopleDoc</Link></li>
                 <li>Choisissez l’année en haut à droite sur <b>{@html htmlLogo}</b></li>
                 <li>Déposez vos fichiers dans <a href="#/mission" >Frais de Mission</a>
                     ou dans <a href="#/pay" >Salaire</a></li>

--- a/src/pages/MissionPage.svelte
+++ b/src/pages/MissionPage.svelte
@@ -27,10 +27,10 @@
         
         <DropZone>
             <div slot="top">
-                Déposez vos <strong>EP5</strong> dans la zone ou Cliquez
+                Déposez vos <strong>relevés d’activité</strong> (AF&#8239;: EP5 / TO&#8239;: Relevé d’activité rémunérée PV) dans la zone ou Cliquez
             </div>
             <div slot="bottom">
-            <MonthStatus data={$rotations} name="EP5" />
+            <MonthStatus data={$rotations} name="Relevés d’activité" />
             </div>
         </DropZone>
         <MissionActivities />


### PR DESCRIPTION
## Summary

This PR serves as a UI cleanup pass now that AF + TO are both first-class carriers. Drops AF-only text and visuals throughout `PayTable`, the upload zones, and `Help.md`; reworks the `PayTable` layout and footnotes so they work cleanly for AF-only, TO-only, and mixed-airline pilots; and fixes a PDF-export regression introduced by the new footnote structure.

<img width="820" height="1180" alt="Screenshot 2026-05-21 at 16 45 12" src="https://github.com/user-attachments/assets/d3d55ab1-ea4e-4234-93b5-572c7bceaa06" />

-----

Three commits, each independently reviewable:

### `feat(paytable)` — bafa5a9

The bulk of the change. PayTable.svelte only.

- **Drop the "Découchers F PRO" column.** AF-only (TO has the rubrique hardcoded to 0); the footnote already told users it was estimation-only; #45 captured the call to remove it earlier. The underlying `totalDecouchersFPRO` and `nightsCostEstimate` reactives stay — they still feed the Nuitées input placeholder for AF-without-attestation pilots.
- **Rename "Nuitées AF" → "Frais d'hébergement"** in the Comparatif. Same field, airline-agnostic meaning.
- **Empty-state hint** now spells out both doc names: `relevés d'activité (AF : EP5 / TO : Relevé d'activité rémunérée PV)`.
- **Footnotes as a real `<ol class="footnotes">`** so list-item indentation works (text wraps under content, not under the digit). Each footnote gains an optional `<details>` reveal listing the per-airline rubrique lines that contribute, rendered as a monospace nested `<ul>`.
- **Third (conditional) footnote** for TO pilots reminding them to enter Frais d'hébergement Transavia manually — TO doesn't publish an attestation; the calculation has to come from the per-night barème (cf. Help.md).
- **AF nuitées attestation no longer disables the input.** Mixed AF+TO pilots can edit the AF value to add their TO total on top. The attestation amount is surfaced as a caption above the Comparatif (`L'attestation Air France indique X €`), parallel to the existing ±20 % estimation caption.
- **Bold the last-cumul-per-airline cell** via a `cumul-max` class derived from a `lastBulletinByAirline` reactive (matches by `paymentDate`, replaces the old `tr.december > td:nth-last-child(3)` rule which after the column drop was pointing at the wrong column anyway).
- **±20 % estimation caption gated on `hasAFPayslips`** — it's AF-specific (TO's `decouchers_fpro` is 0), and was misleading on TO-only loads.
- **CSS regression fix**: `td:nth-last-child(-n+4)` → `(-n+3)` so the Compagnie column regains its center-alignment after dropping Découchers.
- **col1** widened 140 → 180 px to fit "Frais d'hébergement"; **input** switched to `width: 100 %; box-sizing: border-box` so it fills its cell.

### `docs/ui` — 0257f6d

Text-only updates outside PayTable. MissionPage drop zone, HomePage onboarding step, Help.md.

- Upload-zone label spells out both doc names (`AF : EP5 / TO : Relevé d'activité rémunérée PV`); MonthStatus name follows the same shape.
- HomePage onboarding keeps the umbrella term short — per-carrier names live in MissionPage and Help.md where they're acted on.
- Help.md gets a multi-airline pass: Objectifs and intro now mention both carriers; "absence d'EP5" alert tagged as AF-specific; "fichier non reconnu" error description gains PV; "Attestation des nuitées AF" section renamed to **Frais d'hébergement** with two sub-sections explaining the AF flow (auto-loaded attestation, ±20 % estimate fallback) and the TO flow (manual entry from the per-night barème, with a pointer at the Frais de Mission découchers récap).

### `fix(pdf)` — 120691d

The new `<ol>` + `<details>` footnote structure broke PayTable's PDF export. jsPDF's `autoTable` plugin, called with `includeHiddenHtml: true` (so the live-app CSS-hidden chrome still appears in the PDF), flattens both `<ol>` and details body into one text blob — list markers vanish, line breaks collapse, the per-airline rubrique reveals dump inline.

The fix walks `#PayTable` before export, swaps each `<ol class="footnotes">` for a flat `<div>` containing `{n}. {content}` entries joined by `<br><br>` (each `<li>` clone has its `<details>` stripped first), and restores the original after `autoTable` returns. Mirrors the existing MissionTable pre/post-render handling in the same function.

## Notable design choices for review

- **Issue #45 / Découchers column** — confirmed via the original issue thread and code trace that the column was purely informational. Calculation kept behind the scenes (placeholder + comparatif math).
- **AF attestation editable + caption** — semantically: the input is always the source of truth for the math (`$fraisHebergementInput || $fraisHebergement || nightsCostEstimate`); the attestation pre-fills it but doesn't lock it. Mixed AF+TO pilots can edit to sum amounts. AF-only pilots see no behavioural difference except a slightly more informative caption.
- **TO Frais d'hébergement reminder** shown only when `hasTOPayslips` — appears above the road-trip info line in the Comparatif tfoot.
- **Footnote `<ol>` + reveal** — the `<details>` rubrique list is power-user territory; collapses by default to keep the data-table footprint small. Hidden entirely in PDF (see `fix(pdf)` commit) since interactive disclosure doesn't translate.

## Test plan

- [x] `npm test` — 188/188 green (no test changes; pure UI).
- [x] Manual smoke (`npm run dev`) on all four pilot scenarios:
  - **AF-only, no attestation**: ±20 % estimation caption + estimate populates Nuitées field. Footnote 1 only. Last-cumul bold on December AF row.
  - **AF-only, with attestation**: `L'attestation Air France indique X €` caption; input editable, pre-filled with X. Footnote 1 only.
  - **TO-only**: No estimation caption. Input empty, user enters manually. Footnote 1 + TO Frais d'hébergement reminder. Last-cumul bold on TO's last reported month.
  - **Mixed AF + TO, with AF attestation**: AF caption shown; input pre-filled with AF total; TO reminder asks user to add TO costs. Last-cumul bold on each airline's last month.
  - In each case: Footnote 2 (transit) appears only when bulletins carry Navigo / train refunds; the details reveal expands and renders the per-airline rubrique list cleanly.
- [x] PDF export (`Télécharger en PDF`) on a mixed scenario — footnotes render numbered with line break between them; details reveal hidden; column widths and column count match the live view. Smoke-tested; output reads correctly.

## Follow-ups (not in scope)

- Automate TO Frais d'hébergement calculation from the découchers récap + a per-night barème (would replace the manual entry the new reminder asks for). Deferred to a later PR since the barème data isn't yet structured.