### PR TITLE
chore: Bump version 2.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.1] - 2026-05-21
+
+### Fixed
+
+- Correction de la rubrique « Utilisation sur l'iPad » de l'aide : les relevés d'activité sont à télécharger de décembre N-1 à __janvier__ N+1 (et non février N+1). Le document de février N+1 mentionné précédemment était en réalité l'EP4-EP5 contenant l'attestation des nuitées Air&nbsp;France, désormais référencée séparément ([@clarkewing](https://github.com/clarkewing))
+
 ## [2.1.0] - 2026-05-21
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "flytax",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "flytax",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "dependencies": {
         "sirv-cli": "^1.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flytax",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "type": "module",
   "scripts": {
     "build": "rollup -c",

--- a/src/pages/Help.md
+++ b/src/pages/Help.md
@@ -24,7 +24,7 @@ __{@html htmlLogo}__ fonctionne pour les PN Air&nbsp;France et Transavia, basés
 
 ## Utilisation sur l'iPad
 
-Sur MyPeopleDoc, commencez par sélectionner les bulletins de salaire de l'année N, et vos relevés d’activité (EP5 pour Air&nbsp;France, Relevé d’activité rémunérée PV pour Transavia) de décembre N-1 à février N+1. Puis, en cliquant sur téléchargement, vous recevrez un lien par email. Dans votre dossier de téléchargement sur l'iPad, cliquez sur l'archive téléchargée, elle va se décompresser. Ensuite, après avoir vérifié que l'année N est bien sélectionnée en haut à droite de  __{@html htmlLogo}__, deux solutions:
+Sur MyPeopleDoc, commencez par sélectionner les bulletins de salaire de l'année N, et vos relevés d’activité (EP5 pour Air&nbsp;France, Relevé d’activité rémunérée PV pour Transavia) de décembre N-1 à janvier N+1. Air&nbsp;France publie également en février N+1 l'attestation des nuitées (voir la rubrique « Frais d’hébergement »). Puis, en cliquant sur téléchargement, vous recevrez un lien par email. Dans votre dossier de téléchargement sur l'iPad, cliquez sur l'archive téléchargée, elle va se décompresser. Ensuite, après avoir vérifié que l'année N est bien sélectionnée en haut à droite de  __{@html htmlLogo}__, deux solutions:
 
 - Soit, vous cliquez dans la zone de la page Frais de Mission ou de la page Salaire, puis vous choisissez le dossier des fichiers décompressés, puis vous cliquez sur "Sélectionner", puis "Tout select." et enfin, "Ouvrir"
 - Soit, vous utilisez le mode Slide Over, ou le mode SplitView, avec l'application Fichiers, et vous faites glisser le dossier des fichiers décompressés dans la zone de la page Frais de Mission ou de la page Salaire


### PR DESCRIPTION
## Summary

Patch release fixing a small inaccuracy in the `Help.md` "Utilisation sur l'iPad" section: activity slips (EP5 / PV) only need to span décembre N-1 → __janvier__ N+1, not février N+1. The février N+1 mention was a hold-over from the legacy "ep4-ep5" wording, where the same archive contained both the activity slip and the AF nuitées attestation. With the multi-airline rewrite that landed in 2.1.0 the umbrella term became "relevés d'activité", which strictly speaking doesn't include the EP4 attestation — so the date range needed tightening.

The fix:
- Activity-slip range corrected to décembre N-1 → janvier N+1.
- New sentence explicitly mentions that Air France also publishes the nuitées attestation in février N+1, with a cross-reference to the dedicated « Frais d'hébergement » section that explains how flytax auto-loads it.

## Test plan

- [x] `npm test` — 188/188 green (no code change; doc only).
- [x] Manual: rendered Help.md reads cleanly; cross-link "Frais d'hébergement" resolves to the section below.