### PR TITLE
chore: Bump version 2.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.2] - 2026-05-25
+
+### Fixed
+
+- Parseur PV Transavia : reconnaissance des relevés d'activité dont les cellules d'une ligne sont regroupées dans un même item PDF séparées par des espaces (plutôt qu'un item par cellule). Auparavant ces relevés étaient acceptés silencieusement sans produire aucune rotation ([@clarkewing](https://github.com/clarkewing))
+- Parseur bulletins de paie Transavia : tolérance des cellules vides en fin de ligne Mois du tableau récapitulatif (Plafond S.S., Allèg. Cotis. Employeur). Les bulletins concernés ne renvoient plus l'erreur « Net imposable non trouvé ». Les erreurs des lignes Mois et Cumul sont désormais distinguées ([@clarkewing](https://github.com/clarkewing))
+
 ## [2.1.1] - 2026-05-21
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "flytax",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "flytax",
-      "version": "2.1.1",
+      "version": "2.1.2",
       "dependencies": {
         "sirv-cli": "^1.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flytax",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "type": "module",
   "scripts": {
     "build": "rollup -c",


### PR DESCRIPTION
## Summary
Patch release bundling two user-reported Transavia parser fixes.

- **PV parser** (#68) — Recognize relevés d'activité where pdf.js groups several cells into a single text item separated by multi-space gaps (e.g. `"20:45    23:40    20:41    23:28    2.78"`). Previously these PDFs were detected but produced zero rotations with no error surfaced.
- **Payslip parser** (#69) — Tolerate blank trailing cells on the Mois row of the summary table (Plafond S.S., Allèg. Cotis. Employeur are routinely blank for the month even when Cumul carries them). Mois and Cumul are now matched by independent regexes, so an anomaly on one row no longer loses us the other, and the two failure modes report distinctly.

## Test plan
- [x] `npm test` — 190 passing
- [x] `package.json` / `package-lock.json` / CHANGELOG / tag will all read `2.1.2`